### PR TITLE
Slight typo in "Typings" example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,10 +375,12 @@ const schema = makePrismaSchema({
   // ... other configs,
   typegenAutoConfig: {
     sources: [
-      source: path.join(__dirname, './relative/path/to/prisma/client'),
-      alias: 'prisma'
-    ]
-  }
+      {
+        source: path.join(__dirname, './relative/path/to/prisma/client'),
+        alias: 'prisma',
+      },
+    ],
+  },
 })
 ```
 


### PR DESCRIPTION
A superficial edit -- missing curly braces.