### PR TITLE
Use given path to prisma.yml when possible

### DIFF
--- a/packages/nexus-prisma-generate/src/config.ts
+++ b/packages/nexus-prisma-generate/src/config.ts
@@ -67,8 +67,8 @@ export function readPrismaYml(prismaYamlPath: string | undefined) {
 function findPrismaConfigFile(
   prismaYmlPath: string | undefined,
 ): string | null {
-  if (prismaYmlPath && !fs.existsSync(prismaYmlPath)) {
-    return null
+  if (prismaYmlPath && fs.existsSync(prismaYmlPath)) {
+    return prismaYmlPath
   }
 
   let definitionPath: string | null = path.join(process.cwd(), 'prisma.yml')


### PR DESCRIPTION
I wasn't able to get `nexus-prisma-generate` 0.3.7 to run because the `findPrismaConfigFile` function as it is ignores the given `--project` flag and overwrites the path. This PR is a fix.