### PR TITLE
Publish uuid scalar when needed

### DIFF
--- a/src/nexus-prisma/NexusPrismaBuilder.ts
+++ b/src/nexus-prisma/NexusPrismaBuilder.ts
@@ -1,4 +1,5 @@
-import { core, enumType, inputObjectType, dynamicOutputProperty } from 'nexus'
+import { core, dynamicOutputProperty, enumType, inputObjectType } from 'nexus'
+import { DynamicOutputPropertyDef } from 'nexus/dist/dynamicProperty'
 import { NexusPrismaParams } from '.'
 import { transformDMMF } from '../dmmf/dmmf-transformer'
 import { ExternalDMMF as DMMF } from '../dmmf/dmmf-types'
@@ -15,9 +16,8 @@ import {
   IArgsNamingStrategy,
   IFieldNamingStrategy,
 } from './NamingStrategies'
-import { dateTimeScalar, GQL_SCALARS_NAMES } from './scalars'
+import { dateTimeScalar, GQL_SCALARS_NAMES, uuidScalar } from './scalars'
 import { getSupportedMutations, getSupportedQueries } from './supported-ops'
-import { DynamicOutputPropertyDef } from 'nexus/dist/dynamicProperty'
 
 interface FieldPublisherConfig {
   alias?: string
@@ -25,11 +25,6 @@ interface FieldPublisherConfig {
   pagination?: boolean | Record<string, boolean>
   filtering?: boolean | Record<string, boolean>
   ordering?: boolean | Record<string, boolean>
-}
-
-type FieldsWithModelName = {
-  fields: DMMF.SchemaField[]
-  mapping: DMMF.Mapping
 }
 
 export class NexusPrismaBuilder {
@@ -61,7 +56,7 @@ export class NexusPrismaBuilder {
   }
 
   build() {
-    return [this.buildCRUD(), this.buildModel(), ...this.buildScalers()]
+    return [this.buildCRUD(), this.buildModel(), ...this.buildScalars()]
   }
 
   /**
@@ -505,7 +500,7 @@ export class NexusPrismaBuilder {
     return inputTypeName
   }
 
-  protected buildScalers() {
+  protected buildScalars() {
     const allScalarNames = flatMap(this.dmmf.schema.outputTypes, o => o.fields)
       .filter(
         f =>
@@ -518,6 +513,10 @@ export class NexusPrismaBuilder {
 
     if (dedupScalarNames.includes('DateTime')) {
       scalars.push(dateTimeScalar)
+    }
+
+    if (dedupScalarNames.includes('UUID')) {
+      scalars.push(uuidScalar)
     }
 
     return scalars

--- a/src/nexus-prisma/scalars.ts
+++ b/src/nexus-prisma/scalars.ts
@@ -1,17 +1,17 @@
-import { scalarType } from 'nexus';
+import { scalarType } from 'nexus'
 
-export const GQL_SCALARS_NAMES = ['Int', 'Float', 'String', 'ID', 'Boolean'];
+export const GQL_SCALARS_NAMES = ['Int', 'Float', 'String', 'ID', 'Boolean']
 
 export const dateTimeScalar = scalarType({
   name: 'DateTime',
-  description: 'DateTime',
-  parseLiteral(value) {
-    return value;
-  },
   serialize(value) {
-    return value;
+    return value
   },
-  parseValue(value) {
-    return value;
+})
+
+export const uuidScalar = scalarType({
+  name: 'UUID',
+  serialize(value) {
+    return value
   },
-});
+})

--- a/tests/__snapshots__/schema.test.ts.snap
+++ b/tests/__snapshots__/schema.test.ts.snap
@@ -152,6 +152,26 @@ input UserPostsOrderByInput {
 "
 `;
 
+exports[`it exposes prisma scalars 1`] = `
+"type A {
+  id: UUID!
+  createdAt: DateTime!
+}
+
+type B {
+  id: ID!
+}
+
+scalar DateTime
+
+type Query {
+  ok: Boolean!
+}
+
+scalar UUID
+"
+`;
+
 exports[`simple schema 1`] = `
 "type Query {
   ok: Boolean!

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -207,3 +207,35 @@ test('it exposes findOne and findMany', async () => {
 
   expect(printSchema(schema)).toMatchSnapshot()
 })
+
+test('it exposes prisma scalars', async () => {
+  const datamodel = `
+  model A {
+    id  String  @default(uuid()) @id @unique
+    createdAt DateTime @default(now())
+  }
+  model B {
+    id  String  @default(cuid()) @id @unique
+  }
+  `
+  // uuid scalar + datetime
+  const A = objectType({
+    name: 'A',
+    definition(t: any) {
+      t.model.id()
+      t.model.createdAt()
+    },
+  })
+
+  // cuid scalar (should map to graphql's 'ID' scalar)
+  const B = objectType({
+    name: 'B',
+    definition(t: any) {
+      t.model.id()
+    },
+  })
+
+  const schema = await generateSchema(datamodel, [A, B])
+
+  expect(printSchema(schema)).toMatchSnapshot()
+})


### PR DESCRIPTION
Fixes #335

Doesn't fix the `BatchPayload` object output type that is missing when using `t.crud.updateMany` though. That should be on a separate issue