### PR TITLE
fix: publish object types that don't map to prisma models…

### DIFF
--- a/tests/__utils.ts
+++ b/tests/__utils.ts
@@ -1,5 +1,5 @@
 import { getDMMF } from '@prisma/photon'
-import { makeSchema } from 'nexus'
+import * as Nexus from 'nexus'
 import { SchemaBuilder } from '../src/builder'
 import * as DMMF from '../src/dmmf'
 import { render as renderTypegen } from '../src/typegen'
@@ -13,7 +13,7 @@ export async function generateSchemaAndTypes(datamodel: string, types: any) {
     dmmf,
   }).build()
 
-  const schema = makeSchema({
+  const schema = Nexus.makeSchema({
     types: [types, nexusPrisma],
     outputs: false,
   })
@@ -21,4 +21,26 @@ export async function generateSchemaAndTypes(datamodel: string, types: any) {
   const typegen = renderTypegen(dmmf, '@generated/photon')
 
   return { schema: printSchema(schema), typegen }
+}
+
+export async function generateSchemaAndTypesWithoutThrowing(
+  datamodel: string,
+  types: any,
+) {
+  const dmmf = DMMF.fromPhotonDMMF(await getDMMF({ datamodel }))
+  const nexusPrisma = new SchemaBuilder({
+    types,
+    dmmf,
+  }).build()
+  const schemaAndMissingTypes = Nexus.core.makeSchemaInternal({
+    types: [types, nexusPrisma],
+    outputs: false,
+  })
+  const typegen = renderTypegen(dmmf, '@generated/photon')
+
+  return {
+    schema: printSchema(schemaAndMissingTypes.schema),
+    missingTypes: schemaAndMissingTypes.missingTypes,
+    typegen,
+  }
 }

--- a/tests/outputs.test.ts
+++ b/tests/outputs.test.ts
@@ -1,0 +1,31 @@
+import * as Nexus from 'nexus'
+import { generateSchemaAndTypesWithoutThrowing } from './__utils'
+
+it('only publishes output types that do not map to prisma models', async () => {
+  const datamodel = `
+  model User {
+    id  Int @id
+    name String
+  }
+`
+  const Query = Nexus.objectType({
+    name: 'Query',
+    definition(t: any) {
+      t.crud.user()
+    },
+  })
+
+  const Mutation = Nexus.objectType({
+    name: 'Mutation',
+    definition(t: any) {
+      t.crud.updateManyUser({ filtering: true })
+    },
+  })
+
+  const { missingTypes } = await generateSchemaAndTypesWithoutThrowing(
+    datamodel,
+    [Query, Mutation],
+  )
+
+  expect(Object.keys(missingTypes)).toEqual(['User'])
+})


### PR DESCRIPTION
Object types should be auto-published only in case their names don't match a Prisma model name.

This fix allows us to properly auto-publish `BatchPayload`, but keep forcing users to define their top-level object types

Related to: https://github.com/prisma-labs/nexus-prisma/pull/441#issuecomment-538970758