### PR TITLE
fix: generated publishers are now all camel-cased

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@prisma/photon": "^0.2.94",
+    "camelcase": "^5.3.1",
     "fs-extra": "^8.1.0",
     "nexus": "^0.12.0-beta.12",
     "pluralize": "^8.0.0"

--- a/src/dmmf/DMMFClass.ts
+++ b/src/dmmf/DMMFClass.ts
@@ -128,7 +128,7 @@ export class OutputType {
 
     if (!field) {
       throw new Error(
-        `Could not find field field '${fieldName}' on type ${this.outputType.name}`,
+        `Could not find field '${this.outputType.name}.${fieldName}' on type ${this.outputType.name}`,
       )
     }
 

--- a/src/naming-strategies.ts
+++ b/src/naming-strategies.ts
@@ -1,6 +1,7 @@
 import pluralize from 'pluralize'
 import * as DMMF from './dmmf'
 import { upperFirst } from './utils'
+import camelCase from 'camelcase'
 
 export interface ArgsNamingStrategy {
   whereInput: (typeName: string, fieldName: string) => string
@@ -28,8 +29,8 @@ export type FieldNamingStrategy = Record<
 >
 
 export const defaultFieldNamingStrategy: FieldNamingStrategy = {
-  findOne: (_, modelName) => modelName.toLowerCase(),
-  findMany: (_, modelName) => pluralize(modelName).toLowerCase(),
+  findOne: (_, modelName) => camelCase(modelName),
+  findMany: (_, modelName) => camelCase(pluralize(modelName)),
   create: fieldName => fieldName,
   update: fieldName => fieldName,
   delete: fieldName => fieldName,

--- a/tests/__snapshots__/naming.test.ts.snap
+++ b/tests/__snapshots__/naming.test.ts.snap
@@ -1,0 +1,341 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generates publishers pluralized & camel-cased: schema 1`] = `
+"type BatchPayload {
+  count: Int!
+}
+
+input IntFilter {
+  equals: Int
+  not: Int
+  in: [Int!]
+  notIn: [Int!]
+  lt: Int
+  lte: Int
+  gt: Int
+  gte: Int
+}
+
+type ModelName {
+  id: Int!
+}
+
+input ModelNameCreateInput {
+  name: String!
+}
+
+input ModelNameUpdateInput {
+  id: Int
+  name: String
+}
+
+input ModelNameUpdateManyMutationInput {
+  id: Int
+  name: String
+}
+
+input ModelNameWhereInput {
+  id: IntFilter
+  name: StringFilter
+  AND: [ModelNameWhereInput!]
+  OR: [ModelNameWhereInput!]
+  NOT: [ModelNameWhereInput!]
+}
+
+input ModelNameWhereUniqueInput {
+  id: Int
+}
+
+type Mutation {
+  createOneModelName(data: ModelNameCreateInput!): ModelName!
+  deleteOneModelName(where: ModelNameWhereUniqueInput!): ModelName
+  updateOneModelName(data: ModelNameUpdateInput!, where: ModelNameWhereUniqueInput!): ModelName
+  upsertOneModelName(where: ModelNameWhereUniqueInput!, create: ModelNameCreateInput!, update: ModelNameUpdateInput!): ModelName!
+  updateManyModelName(data: ModelNameUpdateManyMutationInput!, where: ModelNameWhereInput): BatchPayload!
+}
+
+type Query {
+  modelName(where: ModelNameWhereUniqueInput!): ModelName
+  modelNames(skip: Int, after: String, before: String, first: Int, last: Int): [ModelName!]!
+}
+
+input StringFilter {
+  equals: String
+  not: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+}
+"
+`;
+
+exports[`generates publishers pluralized & camel-cased: typegen 1`] = `
+"import * as photon from '@generated/photon';
+import { core } from 'nexus';
+// Types helpers
+  type IsModelNameExistsInGraphQLTypes<
+  ReturnType extends any
+> = ReturnType extends core.GetGen<'objectNames'> ? true : false;
+
+type NexusPrismaScalarOpts = {
+  alias?: string;
+};
+
+type Pagination = {
+  first?: boolean;
+  last?: boolean;
+  before?: boolean;
+  after?: boolean;
+  skip?: boolean;
+};
+
+type RootObjectTypes = Pick<
+  core.GetGen<'rootTypes'>,
+  core.GetGen<'objectNames'>
+>;
+
+/**
+ * Determine if \`B\` is a subset (or equivalent to) of \`A\`.
+*/
+type IsSubset<A, B> = keyof A extends never
+  ? false
+  : B extends A
+  ? true
+  : false;
+
+type OmitByValue<T, ValueType> = Pick<
+  T,
+  { [Key in keyof T]: T[Key] extends ValueType ? never : Key }[keyof T]
+>;
+
+type GetSubsetTypes<ModelName extends any> = keyof OmitByValue<
+  {
+    [P in keyof RootObjectTypes]: ModelName extends keyof ModelTypes
+      ? IsSubset<RootObjectTypes[P], ModelTypes[ModelName]> extends true
+        ? RootObjectTypes[P]
+        : never
+      : never;
+  },
+  never
+>;
+
+type SubsetTypes<ModelName extends any> = GetSubsetTypes<
+  ModelName
+> extends never
+  ? \`ERROR: No subset types are available. Please make sure that one of your GraphQL type is a subset of your t.model('<ModelName>')\`
+  : GetSubsetTypes<ModelName>;
+
+type DynamicRequiredType<ReturnType extends any> = IsModelNameExistsInGraphQLTypes<
+  ReturnType
+> extends true
+  ? { type?: SubsetTypes<ReturnType> }
+  : { type: SubsetTypes<ReturnType> };
+
+type GetNexusPrismaInput<
+  ModelName extends any,
+  MethodName extends any,
+  InputName extends 'filtering' | 'ordering'
+> = ModelName extends keyof NexusPrismaInputs
+  ? MethodName extends keyof NexusPrismaInputs[ModelName]
+    ? NexusPrismaInputs[ModelName][MethodName][InputName]
+    : never
+  : never;
+
+type NexusPrismaRelationOpts<
+  ModelName extends any,
+  MethodName extends any,
+  ReturnType extends any
+> = GetNexusPrismaInput<
+  // If GetNexusPrismaInput returns never, it means there are no filtering/ordering args for it. So just use \`alias\` and \`type\`
+  ModelName,
+  MethodName,
+  'filtering'
+> extends never
+  ? {
+      alias?: string;
+    } & DynamicRequiredType<ReturnType>
+  : {
+      alias?: string;
+      filtering?:
+        | boolean
+        | Partial<
+            Record<
+              GetNexusPrismaInput<ModelName, MethodName, 'filtering'>,
+              boolean
+            >
+          >;
+      ordering?:
+        | boolean
+        | Partial<
+            Record<
+              GetNexusPrismaInput<ModelName, MethodName, 'ordering'>,
+              boolean
+            >
+          >;
+      pagination?: boolean | Pagination;
+    } & DynamicRequiredType<ReturnType>;
+
+type IsScalar<TypeName extends any> = TypeName extends core.GetGen<'scalarNames'>
+  ? true
+  : false;
+
+type IsObject<Name extends any> = Name extends core.GetGen<'objectNames'>
+  ? true
+  : false
+
+type IsEnum<Name extends any> = Name extends core.GetGen<'enumNames'>
+  ? true
+  : false
+
+type IsInputObject<Name extends any> = Name extends core.GetGen<'inputNames'>
+  ? true
+  : false
+
+/**
+ * The kind that a GraphQL type may be.
+ */
+type Kind = 'Enum' | 'Object' | 'Scalar' | 'InputObject'
+
+/**
+ * Helper to safely reference a Kind type. For example instead of the following
+ * which would admit a typo:
+ *
+ * \`\`\`ts
+ * type Foo = Bar extends 'scalar' ? ...
+ * \`\`\`
+ *
+ * You can do this which guarantees a correct reference:
+ *
+ * \`\`\`ts
+ * type Foo = Bar extends AKind<'Scalar'> ? ...
+ * \`\`\`
+ *
+ */
+type AKind<T extends Kind> = T
+
+type GetKind<Name extends any> = IsEnum<Name> extends true
+  ? 'Enum'
+  : IsScalar<Name> extends true
+  ? 'Scalar'
+  : IsObject<Name> extends true
+  ? 'Object'
+  : IsInputObject<Name> extends true
+  ? 'InputObject'
+  // FIXME should be \`never\`, but GQL objects named differently
+  // than backing type fall into this branch
+  : 'Object'
+
+type NexusPrismaFields<ModelName extends keyof NexusPrismaTypes> = {
+  [MethodName in keyof NexusPrismaTypes[ModelName]]: NexusPrismaMethod<
+    ModelName,
+    MethodName,
+    GetKind<NexusPrismaTypes[ModelName][MethodName]> // Is the return type a scalar?
+  >;
+};
+
+type NexusPrismaMethod<
+  ModelName extends keyof NexusPrismaTypes,
+  MethodName extends keyof NexusPrismaTypes[ModelName],
+  ThisKind extends Kind,
+  ReturnType extends any = NexusPrismaTypes[ModelName][MethodName]
+> =
+  ThisKind extends AKind<'Enum'>
+  ? () => NexusPrismaFields<ModelName>
+  : ThisKind extends AKind<'Scalar'>
+  ? (opts?: NexusPrismaScalarOpts) => NexusPrismaFields<ModelName> // Return optional scalar opts
+  : IsModelNameExistsInGraphQLTypes<ReturnType> extends true // If model name has a mapped graphql types
+  ? (
+      opts?: NexusPrismaRelationOpts<ModelName, MethodName, ReturnType>
+    ) => NexusPrismaFields<ModelName> // Then make opts optional
+  : (
+      opts: NexusPrismaRelationOpts<ModelName, MethodName, ReturnType>
+    ) => NexusPrismaFields<ModelName>; // Else force use input the related graphql type -> { type: '...' }
+
+type GetNexusPrismaMethod<
+  TypeName extends string
+> = TypeName extends keyof NexusPrismaMethods
+  ? NexusPrismaMethods[TypeName]
+  : <CustomTypeName extends keyof ModelTypes>(
+      typeName: CustomTypeName
+    ) => NexusPrismaMethods[CustomTypeName];
+
+type GetNexusPrisma<
+  TypeName extends string,
+  ModelOrCrud extends 'model' | 'crud'
+> = ModelOrCrud extends 'model'
+  ? TypeName extends 'Mutation'
+    ? never
+    : TypeName extends 'Query'
+    ? never
+    : GetNexusPrismaMethod<TypeName>
+  : ModelOrCrud extends 'crud'
+  ? TypeName extends 'Mutation'
+    ? GetNexusPrismaMethod<TypeName>
+    : TypeName extends 'Query'
+    ? GetNexusPrismaMethod<TypeName>
+    : never
+  : never;
+  
+
+// Generated
+interface ModelTypes {
+  ModelName: photon.ModelName
+}
+  
+interface NexusPrismaInputs {
+  Query: {
+    modelNames: {
+  filtering: 'id' | 'name' | 'AND' | 'OR' | 'NOT'
+  ordering: 'id' | 'name'
+}
+
+  },
+    ModelName: {
+
+
+  }
+}
+
+interface NexusPrismaTypes {
+  Query: {
+    modelName: 'ModelName'
+    modelNames: 'ModelName'
+
+  },
+  Mutation: {
+    createOneModelName: 'ModelName'
+    updateOneModelName: 'ModelName'
+    updateManyModelName: 'BatchPayload'
+    deleteOneModelName: 'ModelName'
+    deleteManyModelName: 'BatchPayload'
+    upsertOneModelName: 'ModelName'
+
+  },
+  ModelName: {
+    id: 'Int'
+    name: 'String'
+
+}
+}
+
+interface NexusPrismaMethods {
+  ModelName: NexusPrismaFields<'ModelName'>
+  Query: NexusPrismaFields<'Query'>
+  Mutation: NexusPrismaFields<'Mutation'>
+}
+  
+
+declare global {
+  type NexusPrisma<
+    TypeName extends string,
+    ModelOrCrud extends 'model' | 'crud'
+  > = GetNexusPrisma<TypeName, ModelOrCrud>;
+}
+  "
+`;

--- a/tests/naming.test.ts
+++ b/tests/naming.test.ts
@@ -1,0 +1,45 @@
+import * as Nexus from 'nexus'
+import { generateSchemaAndTypes } from './__utils'
+
+it('generates publishers pluralized & camel-cased', async () => {
+  const datamodel = `
+  model ModelName {
+    id    Int @id
+    name  String
+  }
+`
+
+  const ModelName = Nexus.objectType({
+    name: 'ModelName',
+    definition(t: any) {
+      t.model.id()
+    },
+  })
+  const Query = Nexus.objectType({
+    name: 'Query',
+    definition(t: any) {
+      t.crud.modelName()
+      t.crud.modelNames()
+    },
+  })
+
+  const Mutation = Nexus.objectType({
+    name: 'Mutation',
+    definition(t: any) {
+      t.crud.createOneModelName()
+      t.crud.deleteOneModelName()
+      t.crud.updateOneModelName()
+      t.crud.upsertOneModelName()
+      t.crud.updateManyModelName()
+    },
+  })
+
+  const { schema, typegen } = await generateSchemaAndTypes(datamodel, [
+    Query,
+    Mutation,
+    ModelName,
+  ])
+
+  expect(schema).toMatchSnapshot('schema')
+  expect(typegen).toMatchSnapshot('typegen')
+})


### PR DESCRIPTION
BREAKING CHANGE: publishers accessed using old lower-case naming will break

- Introduce a new dep: [`camelcase`](https://github.com/sindresorhus/camelcase)
- Fixes #435