### PR TITLE
Monorepo support by resolving generated types

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -118,7 +118,7 @@ if (process.env.NEXUS_PRISMA_PHOTON_PATH) {
     '/node_modules/@generated/photon',
   )
 } else {
-  defaultPhotonPath = '@generated/photon'
+  defaultPhotonPath = require.resolve('@generated/photon')
 }
 
 // NOTE This will be repalced by Nexus plugins once typegen integration is available.


### PR DESCRIPTION
When multiple 'node_modules' directories are in use, using `require.resolve` looks up the `@generated/photon` package recursively.