### PR TITLE
fix(typegen): normalize generated path on windows

### DIFF
--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as DMMF from './dmmf'
 import { getCrudMappedFields } from './mapping'
 import { defaultFieldNamingStrategy } from './naming-strategies'
@@ -33,7 +34,7 @@ export function doGenerate(
 
 export function render(dmmf: DMMF.DMMF, photonPath: string) {
   return `\
-import * as photon from '${photonPath}';
+import * as photon from '${photonPath.split(path.sep).join('/')}';
 import { core } from 'nexus';
 // Types helpers
 ${renderStaticTypes()}


### PR DESCRIPTION
Previously, the generator would output statements like:

```ts
import * as photon from 'D:\Development\Projects\app\server\node_modules\@generated\photon\index.js';
```

Which is invalid, as the `\` characted should be escaped to `\\`. Luckily, Windows also accepts `/` as a separator, providing a universal solution compatible with all the platforms:

```ts
import * as photon from 'D:/Development/Projects/app/server/node_modules/@generated/photon/index.js';
```