### PR TITLE
feat: prevent errors if a wrong field is projected

### DIFF
--- a/src/proxifier.ts
+++ b/src/proxifier.ts
@@ -1,0 +1,48 @@
+import * as Nexus from 'nexus'
+
+export type OnUnknownFieldName = (info: {
+  unknownFieldName: string
+  error: Error
+  validFieldNames: string[]
+  typeName: string
+}) => void
+
+export function proxify<T extends object>(
+  publishers: T,
+  typeName: string,
+  stage: Nexus.core.OutputFactoryConfig<any>['stage'],
+  modelOrCrud: 'model' | 'crud',
+  onUnknownFieldName?: OnUnknownFieldName,
+) {
+  return new Proxy(publishers, {
+    get(target: any, key) {
+      if (target[key]) {
+        return target[key]
+      }
+
+      if (stage === 'build') {
+        const unknownFieldName = String(key)
+        const message =
+          modelOrCrud === 'model'
+            ? `t.model.${unknownFieldName}() does not map to a field in your Prisma Schema.`
+            : `t.crud.${unknownFieldName}() is not a valid CRUD field given your Prisma Schema.`
+        if (onUnknownFieldName) {
+          onUnknownFieldName({
+            unknownFieldName,
+            typeName,
+            error: new Error(message),
+            validFieldNames: Object.keys(publishers),
+          })
+        } else {
+          if (process.env.NODE_ENV !== 'production') {
+            console.log(`Warning: ${message}`)
+          } else {
+            throw new Error(message)
+          }
+        }
+      }
+
+      return () => {}
+    },
+  })
+}

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,0 +1,38 @@
+import { objectType } from 'nexus'
+import { generateSchemaAndTypes } from './__utils'
+
+it('warns when wrong projected field or crud', async () => {
+  const datamodel = `
+  model User {
+    id  Int @id
+    username String
+  }
+`
+
+  const User = objectType({
+    name: 'User',
+    definition(t: any) {
+      t.model.id()
+      t.model.userName() // wrong projected field
+    },
+  })
+
+  const Query = objectType({
+    name: 'Query',
+    definition(t: any) {
+      t.crud.userss({ filtering: true }) // wrong crud field
+    },
+  })
+
+  let outputData = ''
+  const storeLog = (inputs: string) => (outputData += '\n' + inputs)
+  console.log = jest.fn(storeLog)
+
+  await generateSchemaAndTypes(datamodel, [Query, User])
+
+  expect(outputData).toMatchInlineSnapshot(`
+    "
+    Warning: t.crud.userss() is not a valid CRUD field given your Prisma Schema.
+    Warning: t.model.userName() does not map to a field in your Prisma Schema."
+  `)
+})


### PR DESCRIPTION
- Only when NODE_ENV !== 'production'
- Add a hook for pumpkins. If such hook is present, it lets the hook log the error

Fixes #472