### PR TITLE
fix(typegen): support serverless and windows

### DIFF
--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -31,7 +31,6 @@ export function doGenerate(
   options: Options,
 ): void | Promise<void> {
   const dmmf = DMMF.get(options.photonPath)
-  console.log({ options })
   const tsDeclaration = render(
     dmmf,
     isModule(options.photonPath)

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as DMMF from './dmmf'
 import { getCrudMappedFields } from './mapping'
 import { defaultFieldNamingStrategy } from './naming-strategies'
@@ -23,7 +24,14 @@ export function doGenerate(
   options: Options,
 ): void | Promise<void> {
   const dmmf = DMMF.get(options.photonPath)
-  const tsDeclaration = render(dmmf, options.photonPath)
+  const tsDeclaration = render(
+    dmmf,
+    // Support Serverless platforms by resolving module paths relatively
+    './' +
+      path
+        .relative(path.dirname(options.typegenPath), options.photonPath)
+        .replace(/\\/g, '/'), // Use '/' instead of '\' on Windows
+  )
   if (sync) {
     hardWriteFileSync(options.typegenPath, tsDeclaration)
   } else {

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -17,7 +17,7 @@ export function generate(options: Options): Promise<void> {
   return doGenerate(false, options)
 }
 
-function isModule(name: string) {
+function isPackage(name: string) {
   return (
     !name.includes('/') ||
     (name.startsWith('@') && (name.match(/\//g) || []).length === 1)

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -17,6 +17,13 @@ export function generate(options: Options): Promise<void> {
   return doGenerate(false, options)
 }
 
+function isModule(name: string) {
+  return (
+    !name.includes('/') ||
+    (name.startsWith('@') && (name.match(/\//g) || []).length === 1)
+  )
+}
+
 export function doGenerate(sync: true, options: Options): void
 export function doGenerate(sync: false, options: Options): Promise<void>
 export function doGenerate(
@@ -24,13 +31,16 @@ export function doGenerate(
   options: Options,
 ): void | Promise<void> {
   const dmmf = DMMF.get(options.photonPath)
+  console.log({ options })
   const tsDeclaration = render(
     dmmf,
-    // Support Serverless platforms by resolving module paths relatively
-    './' +
-      path
-        .relative(path.dirname(options.typegenPath), options.photonPath)
-        .replace(/\\/g, '/'), // Use '/' instead of '\' on Windows
+    isModule(options.photonPath)
+      ? options.photonPath
+      : // Support Serverless platforms by resolving module paths relatively
+        './' +
+          path
+            .relative(path.dirname(options.typegenPath), options.photonPath)
+            .replace(/\\/g, '/'), // Use '/' instead of '\' on Windows
   )
   if (sync) {
     hardWriteFileSync(options.typegenPath, tsDeclaration)

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,4 +1,5 @@
 import * as cp from 'child_process'
+import * as os from 'os'
 import * as path from 'path'
 import * as nexusBuilder from 'nexus/dist/builder'
 import * as NexusPrisma from '../src'
@@ -7,6 +8,10 @@ import * as types from './__app/main'
 
 // IDEA Future tests?
 // - show we gracefully handle case of photon import failing
+
+function quoteOnWindows(str: string) {
+  return os.platform() === 'win32' ? '"' + str + '"' : str
+}
 
 it('integrates together', async () => {
   // Setup file system vars & helpers
@@ -17,7 +22,7 @@ it('integrates together', async () => {
     fs.readFile(path.join(projectRoot, relPath)).then(b => b.toString())
 
   const projectPath = (...paths: string[]): string =>
-    path.join(projectRoot, ...paths)
+    path.join(projectRoot, ...paths).replace(/\\/g, '/')
 
   // Remove generated files before test run. The idea here is as follows:
   //
@@ -34,7 +39,7 @@ it('integrates together', async () => {
   // Run Prisma generation:
   // - Photon JS Client
   //
-  cp.execSync('../../node_modules/.bin/prisma2 generate', {
+  cp.execSync(quoteOnWindows('../../node_modules/.bin/prisma2') + ' generate', {
     cwd: projectRoot,
   })
 


### PR DESCRIPTION
Previously, the type generator would output statements like:

```ts
import * as photon from 'C:\Development\Projects\exigo\server\src\functions\graphql\.generated\photon';
```

Which is invalid, as the `\` characted should be escaped to `\\`. Luckily, Windows also accepts `/` as a separator, providing a universal solution compatible with all the platforms:

```ts
import * as photon from 'C:/Development/Projects/exigo/server/src/functions/graphql/.generated/photon';
```

In addition to this, Serverless platforms (e.g. Netlify Functions) may not support absolute paths, so the module path given above should be resolved relative to the containing directory of the generated types, e.g.:

```ts
import * as photon from './.generated/photon/index.js';
```

Given the schema configuration below:

```ts
import { makeSchema } from 'nexus';
import { nexusPrismaPlugin } from 'nexus-prisma';
import * as path from 'path';

export default makeSchema({
  types: [/* ... */],
  plugins: [
    nexusPrismaPlugin({
      inputs: {
        photon: path.join(__dirname, '../.generated/photon'),
      },
      outputs: {
        typegen: path.join(__dirname, '../nexus-prisma.generated.d.ts'),
      },
    }),
  ],
  outputs: {
    typegen: path.join(__dirname, '../nexus.generated.d.ts'),
  },
});
```