### PR TITLE
docs: add community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,13 +576,13 @@ These are tips to help you with a successful project workflow
    though this would still be helpful since yarn rebuilds all packages whenever
    the dependency tree changes in any way
    ([issue](https://github.com/yarnpkg/yarn/issues/4703)). The
-   `NODE_ENV=development` is needed to ensure typegen is run even in a context where `NODE_ENV` is set to `production` (like a heroku deploy pipeline, see next point).
+   `NODE_ENV=development` is needed to ensure typegen is run even in a context where `NODE_ENV` is set to `production` (like a heroku deploy pipeline, see next point). Also, consider using [cross-env][https://github.com/kentcdodds/cross-env] for better compatibility with different environments, e.g. on Windows.
 
    ```json
    {
      "scripts": {
        "generate:prisma": "prisma2 generate",
-       "generate:nexus": "NODE_ENV=development ts-node --transpile-only path/to/schema/module",
+       "generate:nexus": "cross-env NODE_ENV=development ts-node --transpile-only path/to/schema/module",
        "generate": "npm -s run generate:prisma && npm -s run generate:nexus",
        "postinstall": "npm -s run generate"
      }

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ queryType({
 ### Publish Writes on a Prisma Model
 
 ```ts
-queryType({
+mutationType({
   definition(t) {
     t.crud.createPost()
     t.crud.updatePost()

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ If you are still using `nexus-prisma@0.3` / Prisma 1 you can find the old docs [
     - [Batch Filtering](#batch-filtering)
   - [System Behaviours](#system-behaviours)
     - [Null-Free Lists](#null-free-lists)
+- [Community](#community)
+  - [create-nexus-type](#create-nexus-type)
 - [Development](#development)
   - [link workflow with the blog example](#link-workflow-with-the-blog-example)
 - [Links](#links)
@@ -574,13 +576,13 @@ These are tips to help you with a successful project workflow
    though this would still be helpful since yarn rebuilds all packages whenever
    the dependency tree changes in any way
    ([issue](https://github.com/yarnpkg/yarn/issues/4703)). The
-   `NODE_ENV=development` is needed to ensure typegen is run even in a context where `NODE_ENV` is set to `production` (like a heroku deploy pipeline, see next point). Also, consider using [cross-env][https://github.com/kentcdodds/cross-env] for better compatibility with different environments, e.g. on Windows.
+   `NODE_ENV=development` is needed to ensure typegen is run even in a context where `NODE_ENV` is set to `production` (like a heroku deploy pipeline, see next point).
 
    ```json
    {
      "scripts": {
        "generate:prisma": "prisma2 generate",
-       "generate:nexus": "cross-env NODE_ENV=development ts-node --transpile-only path/to/schema/module",
+       "generate:nexus": "NODE_ENV=development ts-node --transpile-only path/to/schema/module",
        "generate": "npm -s run generate:prisma && npm -s run generate:nexus",
        "postinstall": "npm -s run generate"
      }
@@ -596,56 +598,6 @@ These are tips to help you with a successful project workflow
      }
    }
    ```
-
-1. You can use [`Create nexus types`](https://github.com/AhmedElywa/create-nexus-type) tool to generate `objectType` , `queryType` and `mutationType` from your `schema.prisma` file for every model.
-
-    **Example**
-    
-    ```prisma
-    model User {
-      id        String   @id @unique @default(cuid())
-      email     String   @unique
-      birthDate DateTime
-      posts     Post[]
-    }
-    ```
-    
-    Output
-    
-    ```ts
-    import { objectType, extendType } from 'nexus'
-    
-    export const User = objectType({
-      name: 'User',
-      definition(t) {
-        t.model.id()
-        t.model.email()
-        t.model.birthDate()
-        t.model.posts()
-      },
-    })
-    
-    export const userQuery = extendType({
-      type: 'Query',
-      definition(t) {
-        t.crud.user()
-        t.crud.users({ filtering: true, ordering: true })
-      },
-    })
-    
-    export const userMutation = extendType({
-      type: 'Mutation',
-      definition(t) {
-        t.crud.createOneUser()
-        t.crud.updateOneUser()
-        t.crud.upsertOneUser()
-        t.crud.deleteOneUser()
-    
-        t.crud.updateManyUser()
-        t.crud.deleteManyUser()
-      },
-    })
-    ```
 
 <br>
 
@@ -2518,6 +2470,141 @@ model User {
 }
 ```
 
+<br>
+
+### Community
+
+#### `create-nexus-type`
+
+You can use [`Create nexus types`](https://github.com/AhmedElywa/create-nexus-type) tool to generate `objectType` , `queryType` and `mutationType` from your `schema.prisma` file for every model.
+
+**Install**
+
+```
+yarn add -D create-nexus-type
+or 
+npm i create-nexus-type --save-dev
+```
+**Command options for `cnt`**
+
+```
+  --schema To add schema file path if you not run command in root of project
+  --outDir Created files output dir default src/types
+  -mq      add this option to create Queries and Mutations for models 
+  -m       add this option to create Mutations
+  -q       add this option to create Queries
+  -f       add this option to add {filtering: true} option to Queries
+  -o       add this option to add {ordering: true} option to Queries
+```
+
+**Example**
+    
+```prisma
+// schema.prisma
+
+generator photonjs {
+  provider = "photonjs"
+}
+
+model User {
+  id        String   @id @unique @default(cuid())
+  email     String   @unique
+  birthDate DateTime
+  posts     Post[]
+}
+
+model Post {
+  id     String @id @unique @default(cuid())
+  author User[]
+}
+```
+
+run 
+
+```
+npx cnt
+```
+
+OutPut
+
+```ts
+// User.ts
+import { objectType } from 'nexus'
+
+export const User = objectType({
+  name: 'User',
+  definition(t) {
+    t.model.id()
+    t.model.email()
+    t.model.birthDate()
+    t.model.posts()
+  },
+})
+```
+
+```ts
+// Post.ts
+import { objectType } from 'nexus'
+
+export const Post = objectType({
+  name: 'Post',
+  definition(t) {
+    t.model.id()
+    t.model.author()
+  },
+})
+```
+
+```ts
+// index.ts
+export * from './User'
+export * from './Post'
+```
+
+**Create Queries and Mutations**
+
+run 
+
+```
+npx cnt --mq -f -o
+```
+
+OutPut
+
+```ts
+import { objectType, extendType } from 'nexus'
+
+export const User = objectType({
+  name: 'User',
+  definition(t) {
+    t.model.id()
+    t.model.email()
+    t.model.birthDate()
+    t.model.posts()
+  },
+})
+
+export const userQuery = extendType({
+  type: 'Query',
+  definition(t) {
+    t.crud.user()
+    t.crud.users({ filtering: true, ordering: true })
+  },
+})
+
+export const userMutation = extendType({
+  type: 'Mutation',
+  definition(t) {
+    t.crud.createOneUser()
+    t.crud.updateOneUser()
+    t.crud.upsertOneUser()
+    t.crud.deleteOneUser()
+
+    t.crud.updateManyUser()
+    t.crud.deleteManyUser()
+  },
+})
+```
 <br>
 
 # Development

--- a/README.md
+++ b/README.md
@@ -597,6 +597,56 @@ These are tips to help you with a successful project workflow
    }
    ```
 
+1. You can use [`Create nexus types`](https://github.com/AhmedElywa/create-nexus-type) tool to generate `objectType` , `queryType` and `mutationType` from your `schema.prisma` file for every model.
+
+**Example**
+
+```prisma
+model User {
+  id        String   @id @unique @default(cuid())
+  email     String   @unique
+  birthDate DateTime
+  posts     Post[]
+}
+```
+
+Output
+
+```ts
+import { objectType, extendType } from 'nexus'
+
+export const User = objectType({
+  name: 'User',
+  definition(t) {
+    t.model.id()
+    t.model.email()
+    t.model.birthDate()
+    t.model.posts()
+  },
+})
+
+export const userQuery = extendType({
+  type: 'Query',
+  definition(t) {
+    t.crud.user()
+    t.crud.users({ filtering: true, ordering: true })
+  },
+})
+
+export const userMutation = extendType({
+  type: 'Mutation',
+  definition(t) {
+    t.crud.createOneUser()
+    t.crud.updateOneUser()
+    t.crud.upsertOneUser()
+    t.crud.deleteOneUser()
+
+    t.crud.updateManyUser()
+    t.crud.deleteManyUser()
+  },
+})
+```
+
 <br>
 
 ## `t.model`

--- a/README.md
+++ b/README.md
@@ -599,53 +599,53 @@ These are tips to help you with a successful project workflow
 
 1. You can use [`Create nexus types`](https://github.com/AhmedElywa/create-nexus-type) tool to generate `objectType` , `queryType` and `mutationType` from your `schema.prisma` file for every model.
 
-**Example**
-
-```prisma
-model User {
-  id        String   @id @unique @default(cuid())
-  email     String   @unique
-  birthDate DateTime
-  posts     Post[]
-}
-```
-
-Output
-
-```ts
-import { objectType, extendType } from 'nexus'
-
-export const User = objectType({
-  name: 'User',
-  definition(t) {
-    t.model.id()
-    t.model.email()
-    t.model.birthDate()
-    t.model.posts()
-  },
-})
-
-export const userQuery = extendType({
-  type: 'Query',
-  definition(t) {
-    t.crud.user()
-    t.crud.users({ filtering: true, ordering: true })
-  },
-})
-
-export const userMutation = extendType({
-  type: 'Mutation',
-  definition(t) {
-    t.crud.createOneUser()
-    t.crud.updateOneUser()
-    t.crud.upsertOneUser()
-    t.crud.deleteOneUser()
-
-    t.crud.updateManyUser()
-    t.crud.deleteManyUser()
-  },
-})
-```
+    **Example**
+    
+    ```prisma
+    model User {
+      id        String   @id @unique @default(cuid())
+      email     String   @unique
+      birthDate DateTime
+      posts     Post[]
+    }
+    ```
+    
+    Output
+    
+    ```ts
+    import { objectType, extendType } from 'nexus'
+    
+    export const User = objectType({
+      name: 'User',
+      definition(t) {
+        t.model.id()
+        t.model.email()
+        t.model.birthDate()
+        t.model.posts()
+      },
+    })
+    
+    export const userQuery = extendType({
+      type: 'Query',
+      definition(t) {
+        t.crud.user()
+        t.crud.users({ filtering: true, ordering: true })
+      },
+    })
+    
+    export const userMutation = extendType({
+      type: 'Mutation',
+      definition(t) {
+        t.crud.createOneUser()
+        t.crud.updateOneUser()
+        t.crud.upsertOneUser()
+        t.crud.deleteOneUser()
+    
+        t.crud.updateManyUser()
+        t.crud.deleteManyUser()
+      },
+    })
+    ```
 
 <br>
 


### PR DESCRIPTION
I created tool to generate `objectType` , `queryType` and `mutationType` from `schema.prisma` file for every model.
I love to share it here in docs.
If you want to move this up or down to put is in right place in docs or change anything, you can ask me to do this.
Thanks