### PR TITLE
docs: Remove unique directive from id field

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ generator prisma_client {
 }
 
 model User {
-  id        String   @id @unique @default(cuid())
+  id        String   @id @default(cuid())
   email     String   @unique
   birthDate DateTime
 }
 
 model Post {
-  id     String @id @unique @default(cuid())
+  id     String   @id @default(cuid())
   author User[]
 }
 


### PR DESCRIPTION
This is not redundant because @id is already a unique indicator.