### PR TITLE
fix: copy context types on postinstall

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,12 +1,10 @@
 const chalk = require('chalk')
 const jetpack = require('fs-jetpack');
 const path = require('path');
-// proccess.env.PWD is undifined on Windows https://github.com/mrblueblue/gettext-loader/issues/18
-const pwd = process.cwd();
-const destDir = path.join(pwd, '..', '@types', 'nexus-plugin-prisma')
 
-jetpack.dir(destDir)
-jetpack.copy(path.join(pwd, 'global-type.d.ts'), path.join(destDir, 'index.d.ts'), { overwrite: true })
+const destDir = path.join(__dirname, '..', '..', '@types', 'nexus-plugin-prisma')
+
+jetpack.copy(path.join(__dirname, '..', 'global-type.d.ts'), path.join(destDir, 'index.d.ts'), { overwrite: true })
 
 console.log(chalk.bold.yellowBright('----------------------------------'))
 console.log(

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -88,6 +88,18 @@ export async function e2eTestPlugin(
   // Assert that nexus-prisma typegen was created
   expect(fs.exists(nexusPrismaTypegenPath)).toStrictEqual('file')
 
+  // Assert that nexus-prisma test context types were created
+
+  const nexusPrismaTestContextTypesPath = Path.join(
+    ctx.dir,
+    'node_modules',
+    '@types',
+    'nexus-plugin-prisma',
+    'index.d.ts'
+  )
+
+  expect(fs.exists(nexusPrismaTestContextTypesPath)).toStrictEqual('file')
+
   // Run nexus build
   const res = await ctx.nexus(['build'], () => {})
 


### PR DESCRIPTION
## Description

- Context types were not longer copied on postinstall
- Add tests to assert that these types are properly copied