### PR TITLE
Add optional generatedPrismaClientPath.

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -98,6 +98,7 @@ export interface Options {
    * default getter returns `ctx.prisma`.
    */
   prismaClient?: PrismaClientFetcher
+  generatedPrismaClientPath?: string
   /**
    * Same purpose as for that used in `Nexus.makeSchema`. Follows the same rules
    * and permits the same environment variables. This configuration will completely
@@ -239,6 +240,7 @@ export class SchemaBuilder {
     if (config.shouldGenerateArtifacts) {
       Typegen.generateSync({
         prismaClientPath: config.inputs.prismaClient,
+        generatedPrismaClientPath: config.inputs.generatedPrismaClientPath,
         typegenPath: config.outputs.typegen,
       })
     }

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -6,6 +6,7 @@ import { hardWriteFile, hardWriteFileSync } from './utils'
 
 type Options = {
   prismaClientPath: string
+  generatedPrismaClientPath?: string
   typegenPath: string
 }
 
@@ -24,7 +25,7 @@ export function doGenerate(
   options: Options,
 ): void | Promise<void> {
   const dmmf = getTransformedDmmf(options.prismaClientPath)
-  const tsDeclaration = render(dmmf, options.prismaClientPath)
+  const tsDeclaration = render(dmmf, options.generatedPrismaClientPath || options.prismaClientPath)
   if (sync) {
     hardWriteFileSync(options.typegenPath, tsDeclaration)
   } else {


### PR DESCRIPTION
Currently, when the nexusTypes.gen.ts is generated, it uses the prismaClientPath which is written as an absolute url. 

If you are doing local development with docker, this poses a problem, as at generation time, the absolute url written is the path inside docker, and shows error on your local path if using a volume mount. 

This PR is to take an optional generatedPrismaClientPath that allows the user to pass as a string the relative path to prisma that will be used in the nexusTypes.gen.ts. 

This is just an example, and can be merged if you are ok with it. Can also come up with a different solution that aligns more with your conventions. Maybe somehow get the relative

I'm posting this as an alternative to forking this repo to get around this. Hopefully it is considered.

Thank you.

Example use case:
<img width="1250" alt="Screen Shot 2020-05-06 at 2 04 22 PM" src="https://user-images.githubusercontent.com/1761197/81228223-8958e600-8fa2-11ea-83fa-8b95ea284198.png">
