### PR TITLE
feat: Add Optional generatedPrismaClientPath path

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -99,6 +99,11 @@ export interface Options {
    */
   prismaClient?: PrismaClientFetcher
   /**
+   * Add optional relate path as string to prisma used in nexusTypes.gen.ts. If not provided,
+   * will use absolute path to prismaClient above.
+   */
+  generatedPrismaClientPath?: string
+  /**
    * Same purpose as for that used in `Nexus.makeSchema`. Follows the same rules
    * and permits the same environment variables. This configuration will completely
    * go away once Nexus has typeGen plugin support.
@@ -188,6 +193,7 @@ const defaultOptions = {
   prismaClient: (ctx: any) => ctx.prisma,
   inputs: {
     prismaClient: defaultClientPath,
+    generatedPrismaClientPath:  undefined
   },
   outputs: {
     typegen: defaultTypegenPath,
@@ -239,6 +245,7 @@ export class SchemaBuilder {
     if (config.shouldGenerateArtifacts) {
       Typegen.generateSync({
         prismaClientPath: config.inputs.prismaClient,
+        generatedPrismaClientPath: config.inputs.generatedPrismaClientPath,
         typegenPath: config.outputs.typegen,
       })
     }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -99,7 +99,7 @@ export interface Options {
    */
   prismaClient?: PrismaClientFetcher
   /**
-   * Add optional relate path as string to prisma used in nexusTypes.gen.ts. If not provided,
+   * Add optional relative path as string for prismaClientPath used in nexusTypes.gen.ts. If not provided,
    * will use absolute path to prismaClient above.
    */
   generatedPrismaClientPath?: string

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -6,6 +6,7 @@ import { hardWriteFile, hardWriteFileSync } from './utils'
 
 type Options = {
   prismaClientPath: string
+  generatedPrismaClientPath?: string
   typegenPath: string
 }
 
@@ -24,7 +25,7 @@ export function doGenerate(
   options: Options,
 ): void | Promise<void> {
   const dmmf = getTransformedDmmf(options.prismaClientPath)
-  const tsDeclaration = render(dmmf, options.prismaClientPath)
+  const tsDeclaration = render(dmmf, options.generatedPrismaClientPath ||options.prismaClientPath)
   if (sync) {
     hardWriteFileSync(options.typegenPath, tsDeclaration)
   } else {


### PR DESCRIPTION
Currently, when the nexusTypes.gen.ts is generated, it uses the prismaClientPath which is written as an absolute url.

If you are doing local development with docker, this poses a problem, as at generation time, the absolute url written is the path inside docker, and shows error on your local path if using a volume mount.

This PR is to take an optional generatedPrismaClientPath that allows the user to pass as a string the relative path to prisma that will be used in the nexusTypes.gen.ts.

This is just an example, and can be merged if you are ok with it. Can also come up with a different solution that aligns more with your conventions. Maybe somehow get the relative

I'm posting this as an alternative to forking this repo to get around this. Hopefully it is considered.

Thank you.

<img width="1250" alt="Screen Shot 2020-05-06 at 2 04 22 PM" src="https://user-images.githubusercontent.com/1761197/81235256-5832e280-8faf-11ea-8e2a-019db8f9ec1a.png">

Without fixing it, when resolving prisma with a custom path, to work with yarn workspaces, It sets the url as an absolute path, and webpack throws an error when trying to resolve it during development mode.

<img width="1660" alt="Screen Shot 2020-05-06 at 6 17 37 PM" src="https://user-images.githubusercontent.com/1761197/81244015-1e210b00-8fc6-11ea-9ecf-5c5cd4fd6c3a.png">

