### PR TITLE
fix: field alias not mapping prisma value

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -473,15 +473,15 @@ export class SchemaBuilder {
           typeName,
           resolve:
             field.outputType.kind === 'object'
-            ? (root, args, ctx) => {
-                const photon = this.getPhoton(ctx)
-                return photon[lowerFirst(mapping.model)]
-                  ['findOne']({
-                    where: { [idField.name]: root[idField.name] },
-                  })
-                  [field.name](args)
-              }
-            : publisherConfig.alias != field.name
+              ? (root, args, ctx) => {
+                  const photon = this.getPhoton(ctx)
+                  return photon[lowerFirst(mapping.model)]
+                    ['findOne']({
+                      where: { [idField.name]: root[idField.name] },
+                    })
+                    [field.name](args)
+                }
+              : publisherConfig.alias != field.name
               ? (root) => root[field.name]
               : undefined,
         })

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -473,14 +473,16 @@ export class SchemaBuilder {
           typeName,
           resolve:
             field.outputType.kind === 'object'
-              ? (root, args, ctx) => {
-                  const photon = this.getPhoton(ctx)
-                  return photon[lowerFirst(mapping.model)]
-                    ['findOne']({
-                      where: { [idField.name]: root[idField.name] },
-                    })
-                    [field.name](args)
-                }
+            ? (root, args, ctx) => {
+                const photon = this.getPhoton(ctx)
+                return photon[lowerFirst(mapping.model)]
+                  ['findOne']({
+                    where: { [idField.name]: root[idField.name] },
+                  })
+                  [field.name](args)
+              }
+            : publisherConfig.alias != field.name
+              ? (root) => root[field.name]
               : undefined,
         })
 

--- a/tests/runtime/field-resolution.test.ts
+++ b/tests/runtime/field-resolution.test.ts
@@ -259,7 +259,7 @@ it('supports aliased model fields', async () => {
 
   await dbClient.aliasedFieldModel.create({
     data: {
-      fullName: 'Jane Smith',
+      full_name: 'Jane Smith',
     },
   })
 

--- a/tests/runtime/field-resolution.test.ts
+++ b/tests/runtime/field-resolution.test.ts
@@ -228,3 +228,54 @@ Object {
 }
 `)
 })
+
+it('supports aliased model fields', async () => {
+  const datamodel = `
+    model AliasedFieldModel {
+      id  Int @id @default(autoincrement())
+      full_name String
+    }
+  `
+
+  const AliasedFieldModel = objectType({
+    name: 'AliasedFieldModel',
+    definition(t: any) {
+      t.model.id()
+      t.model.full_name({alias: 'fullName'})
+    },
+  })
+
+  const Query = objectType({
+    name: 'Query',
+    definition(t: any) {
+      t.crud.aliasedFieldModels()
+    },
+  })
+
+  const { graphqlClient, dbClient } = await ctx.getContext({
+    datamodel,
+    types: [Query, AliasedFieldModel],
+  })
+
+  await dbClient.aliasedFieldModel.create({
+    data: {
+      fullName: 'Jane Smith',
+    },
+  })
+
+  const result = await graphqlClient.request(`{
+    aliasedFieldModels {
+      fullName
+    }
+  }`)
+
+  expect(result).toMatchInlineSnapshot(`
+Object {
+  "aliasedFieldModels": Array [
+    Object {
+      "fullName": "Jane Smith",
+    },
+  ],
+}
+`)
+})


### PR DESCRIPTION
Per #610, Prisma model fields that specify an alias return null in the GraphQL responses. For example:

```typescript
const Customer = objectType({
  type: "Customer",
  definition(t) {
    t.model.full_name({alias: "fullName"})
  }
})
```

The root cause appears to be that the publisher is not providing a resolver in the field config. So when we have a source record from Prisma that looks like this:

```typescript
const prismaSourceObject = {
  "full_name": "Jane Smith"
}
```

Since no custom resolver is specified, the defaultResolver picks it up. The defaultResolver understandably tries extract that value from the source using the alias (e.g. `prismaSourceObject['fullName']`) when it fact it should be extracted from the source via the field name (e.g. `prismaSourceObject['full_name']`). Add a custom resolver appears to fix this.