### PR TITLE
feat: put `t.crud` behind an experimental flag

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -122,6 +122,13 @@ export interface Options {
      */
     typegen?: string
   }
+  /**
+   * Enable experimental CRUD capabilities.
+   * Add a `t.crud` method in your definition block to generate CRUD resolvers in your `Query` and `Mutation` GraphQL Object Type.
+   *
+   * @default false
+   */
+  experimentalCRUD?: boolean
   computedInputs?: GlobalComputedInputs
 }
 
@@ -248,7 +255,11 @@ export class SchemaBuilder {
    * The build entrypoint, bringing together sub-builders.
    */
   build() {
-    return [this.buildCRUD(), this.buildModel()]
+    if (this.options.experimentalCRUD === true) {
+      return [this.buildCRUD(), this.buildModel()]
+    }
+
+    return [this.buildModel()]
   }
 
   /**
@@ -482,7 +493,7 @@ export class SchemaBuilder {
                     [field.name](args)
                 }
               : publisherConfig.alias != field.name
-              ? (root) => root[field.name]
+              ? root => root[field.name]
               : undefined,
         })
 

--- a/tests/__utils.ts
+++ b/tests/__utils.ts
@@ -48,11 +48,12 @@ export async function getPinnedDmmfFromSchema(datamodel: string) {
 export async function generateSchemaAndTypes(
   datamodel: string,
   types: any[],
-  options?: TransformOptions,
+  options?: TransformOptions & { experimentalCRUD?: boolean },
 ) {
   const dmmf = await getDmmf(datamodel, options)
   const nexusPrisma = createNexusPrismaInternal({
     dmmf,
+    experimentalCRUD: options?.experimentalCRUD === false ? false : true,
   })
   const schema = Nexus.makeSchema({
     types,

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -15,7 +15,7 @@ it('integrates together', async () => {
   const projectRoot = path.join(__dirname, '/__app')
 
   const projectReadFile = (relPath: string): Promise<string> =>
-    fs.readFile(path.join(projectRoot, relPath)).then(b => b.toString())
+    fs.readFile(path.join(projectRoot, relPath)).then((b) => b.toString())
 
   const projectPath = (...paths: string[]): string =>
     path.join(projectRoot, ...paths)
@@ -54,6 +54,7 @@ it('integrates together', async () => {
     outputs: {
       typegen: projectPath(`/generated/nexus-prisma-typegen.d.ts`),
     },
+    experimentalCRUD: true,
   })
 
   process.env.NODE_ENV = 'development'


### PR DESCRIPTION
BREAKING CHANGE: `t.crud` is now disabled by default and needs to be enabled via the `experimentalCRUD` option