### PR TITLE
feat: partially support Json type

### DIFF
--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -125,6 +125,7 @@ export class Publisher {
         inputType.fields
           .map(field => {
             // TODO: Do not filter JsonFilter once Prisma implements them
+            // https://github.com/prisma/prisma/issues/2563
             if (['JsonFilter', 'NullableJsonFilter'].includes(field.inputType.type)) {
               return null
             }

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -125,7 +125,7 @@ export class Publisher {
         inputType.fields
           .map(field => {
             // TODO: Do not filter JsonFilter once Prisma implements them
-            if (field.inputType.type === 'JsonFilter') {
+            if (['JsonFilter', 'NullableJsonFilter'].includes(field.inputType.type)) {
               return null
             }
 

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -123,21 +123,30 @@ export class Publisher {
       name: inputType.name,
       definition: t => {
         inputType.fields
-          .map(field => ({
-            ...field,
-            inputType: {
-              ...field.inputType,
-              type: this.isPublished(field.inputType.type)
-                ? // Simply reference the field input type if it's already been visited, otherwise create it
-                  field.inputType.type
-                : this.inputType({
-                    arg: field,
-                    type: this.getTypeFromArg(field),
-                  }),
-            },
-          }))
+          .map(field => {
+            // TODO: Do not filter JsonFilter once Prisma implements them
+            if (field.inputType.type === 'JsonFilter') {
+              return null
+            }
+
+            return {
+              ...field,
+              inputType: {
+                ...field.inputType,
+                type: this.isPublished(field.inputType.type)
+                  ? // Simply reference the field input type if it's already been visited, otherwise create it
+                    field.inputType.type
+                  : this.inputType({
+                      arg: field,
+                      type: this.getTypeFromArg(field),
+                    }),
+              },
+            }
+          })
           .forEach(field => {
-            t.field(field.name, dmmfFieldToNexusFieldConfig(field.inputType))
+            if (field) {
+              t.field(field.name, dmmfFieldToNexusFieldConfig(field.inputType))
+            }
           })
       },
     })

--- a/tests/schema/__snapshots__/scalars.test.ts.snap
+++ b/tests/schema/__snapshots__/scalars.test.ts.snap
@@ -1,0 +1,326 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`publishes date and json scalar output types: schema 1`] = `
+"scalar DateTime
+
+scalar Json
+
+type Query {
+  ok: Boolean!
+}
+
+type User {
+  id: Int!
+  date: DateTime!
+  json: Json!
+}
+"
+`;
+
+exports[`publishes date and json scalar output types: typegen 1`] = `
+"import * as prisma from '@prisma/client';
+import { core } from '@nexus/schema';
+import { GraphQLResolveInfo } from 'graphql';
+
+// Types helpers
+type IsModelNameExistsInGraphQLTypes<ReturnType> =
+  ReturnType extends core.GetGen<'objectNames'>
+    ? true
+    : false
+
+type CustomFieldResolver<TypeName extends string, FieldName extends string> =
+  (
+    root: core.RootValue<TypeName>,
+    args: core.ArgsValue<TypeName, FieldName>,
+    context: core.GetGen<\\"context\\">,
+    info: GraphQLResolveInfo,
+    originalResolve: core.FieldResolver<TypeName, FieldName>
+  ) => core.MaybePromise<core.ResultValue<TypeName, FieldName>> | core.MaybePromiseDeep<core.ResultValue<TypeName, FieldName>>
+
+type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, Alias extends string | undefined> = {
+  alias?: Alias
+  resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
+} & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
+
+type Pagination = {
+  skip?: boolean
+  take?: boolean
+  cursor?: boolean
+}
+
+type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
+
+/**
+ * Determine if \`B\` is a subset (or equivalent to) of \`A\`.
+*/
+type IsSubset<A, B> =
+  keyof A extends never ? false :
+  B extends A           ? true  :
+                          false
+
+type OmitByValue<T, ValueType> =
+  Pick<T, { [Key in keyof T]: T[Key] extends ValueType ? never : Key }[keyof T]>
+
+type GetSubsetTypes<ModelName extends string> =
+  keyof OmitByValue<
+    {
+      [P in keyof RootObjectTypes]:
+        // if
+        ModelName extends keyof ModelTypes
+        ? IsSubset<RootObjectTypes[P], ModelTypes[ModelName]> extends true
+        // else if
+        ? RootObjectTypes[P]
+        : never
+        // else
+        : never
+    },
+    never
+  >
+
+type SubsetTypes<ModelName extends string> =
+  GetSubsetTypes<ModelName> extends never
+    ? \`ERROR: No subset types are available. Please make sure that one of your GraphQL type is a subset of your t.model('<ModelName>')\`
+    : GetSubsetTypes<ModelName>
+
+type DynamicRequiredType<ReturnType extends string> =
+  IsModelNameExistsInGraphQLTypes<ReturnType> extends true
+    ? { type?: SubsetTypes<ReturnType> }
+    : { type: SubsetTypes<ReturnType> }
+
+type GetNexusPrismaInput<
+  ModelName extends string,
+  MethodName extends string,
+  InputName extends 'filtering' | 'ordering'
+> =
+  ModelName extends keyof NexusPrismaInputs
+    ? MethodName extends keyof NexusPrismaInputs[ModelName]
+      ? InputName extends keyof NexusPrismaInputs[ModelName][MethodName]
+        ? NexusPrismaInputs[ModelName][MethodName][InputName] & string
+        : never
+      : never
+    : never
+
+/**
+ *  Represents arguments required by Prisma Client JS that will
+ *  be derived from a request's input (args, context, and info)
+ *  and omitted from the GraphQL API. The object itself maps the
+ *  names of these args to a function that takes an object representing
+ *  the request's input and returns the value to pass to the prisma
+ *  arg of the same name.
+ */
+export type LocalComputedInputs<MethodName extends string> =
+  Record<
+    string,
+    (params: LocalMutationResolverParams<MethodName>) => unknown
+  >
+
+export type GlobalComputedInputs =
+  Record<
+    string,
+    (params: GlobalMutationResolverParams) => unknown
+  >
+
+type BaseMutationResolverParams = {
+  info: GraphQLResolveInfo
+  ctx: Context
+}
+
+export type GlobalMutationResolverParams =
+  BaseMutationResolverParams & {
+    args: Record<string, any> & { data: unknown }
+  }
+
+export type LocalMutationResolverParams<MethodName extends string> =
+  BaseMutationResolverParams & {
+    args: MethodName extends keyof core.GetGen2<'argTypes', 'Mutation'>
+      ? core.GetGen3<'argTypes', 'Mutation', MethodName>
+      : any
+  }
+
+export type Context = core.GetGen<'context'>
+
+type BaseRelationOptions<TypeName extends string, MethodName extends string, Alias extends string | undefined, ReturnType extends string> =
+  DynamicRequiredType<ReturnType> & {
+    alias?: Alias
+    resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
+    computedInputs?: LocalComputedInputs<MethodName>
+  } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
+
+// If GetNexusPrismaInput returns never, it means there are no filtering/ordering args for it.
+type NexusPrismaRelationOpts<ModelName extends string, MethodName extends string, Alias extends string | undefined, ReturnType extends string> =
+  GetNexusPrismaInput<ModelName, MethodName, 'filtering'> extends never
+  ? BaseRelationOptions<ModelName, MethodName, Alias, ReturnType>
+  // else if
+  : GetNexusPrismaInput<ModelName, MethodName, 'ordering'> extends never
+  ? BaseRelationOptions<ModelName, MethodName, Alias, ReturnType>
+  // else
+  : BaseRelationOptions<ModelName, MethodName, Alias, ReturnType> & {
+      filtering?:
+        | boolean
+        | Partial<Record<GetNexusPrismaInput<ModelName, MethodName, 'filtering'>, boolean>>
+      ordering?:
+        | boolean
+        | Partial<Record<GetNexusPrismaInput<ModelName, MethodName, 'ordering'>, boolean>>
+      pagination?: boolean | Pagination
+    }
+
+type IsScalar<TypeName extends string> = TypeName extends core.GetGen<'scalarNames'>
+  ? true
+  : false;
+
+type IsObject<Name extends string> = Name extends core.GetGen<'objectNames'>
+  ? true
+  : false
+
+type IsEnum<Name extends string> = Name extends core.GetGen<'enumNames'>
+  ? true
+  : false
+
+type IsInputObject<Name extends string> = Name extends core.GetGen<'inputNames'>
+  ? true
+  : false
+
+/**
+ * The kind that a GraphQL type may be.
+ */
+type Kind = 'Enum' | 'Object' | 'Scalar' | 'InputObject'
+
+/**
+ * Helper to safely reference a Kind type. For example instead of the following
+ * which would admit a typo:
+ *
+ * \`\`\`ts
+ * type Foo = Bar extends 'scalar' ? ...
+ * \`\`\`
+ *
+ * You can do this which guarantees a correct reference:
+ *
+ * \`\`\`ts
+ * type Foo = Bar extends AKind<'Scalar'> ? ...
+ * \`\`\`
+ *
+ */
+type AKind<T extends Kind> = T
+
+type GetKind<Name extends string> =
+  IsEnum<Name> extends true
+  ? 'Enum'
+  // else if
+  : IsScalar<Name> extends true
+  ? 'Scalar'
+  // else if
+  : IsObject<Name> extends true
+  ? 'Object'
+  // else if
+  : IsInputObject<Name> extends true
+  ? 'InputObject'
+  // else
+  // FIXME should be \`never\`, but GQL objects named differently
+  // than backing type fall into this branch
+  : 'Object'
+
+type NexusPrismaFields<ModelName extends keyof NexusPrismaTypes & string> = {
+  [MethodName in keyof NexusPrismaTypes[ModelName] & string]:
+    NexusPrismaMethod<
+      ModelName,
+      MethodName,
+      GetKind<NexusPrismaTypes[ModelName][MethodName] & string> // Is the return type a scalar?
+    >
+}
+
+type NexusPrismaMethod<
+  ModelName extends keyof NexusPrismaTypes,
+  MethodName extends keyof NexusPrismaTypes[ModelName] & string,
+  ThisKind extends Kind,
+  ReturnType extends string = NexusPrismaTypes[ModelName][MethodName] & string
+> =
+  ThisKind extends AKind<'Enum'>
+  ? () => NexusPrismaFields<ModelName>
+  // else if
+  // if scalar return scalar opts
+  : ThisKind extends AKind<'Scalar'>
+  ? <Alias extends string | undefined = undefined>(opts?: NexusPrismaScalarOpts<ModelName, MethodName, Alias>) => NexusPrismaFields<ModelName>
+  // else if
+  // if model name has a mapped graphql types then make opts optional
+  : IsModelNameExistsInGraphQLTypes<ReturnType> extends true
+  ? <Alias extends string | undefined = undefined>(opts?: NexusPrismaRelationOpts<ModelName, MethodName, Alias, ReturnType>) => NexusPrismaFields<ModelName>
+  // else
+  // force use input the related graphql type -> { type: '...' }
+  : <Alias extends string | undefined = undefined>(opts: NexusPrismaRelationOpts<ModelName, MethodName, Alias, ReturnType>) => NexusPrismaFields<ModelName>
+
+type GetNexusPrismaMethod<TypeName extends string> = TypeName extends keyof NexusPrismaMethods
+  ? NexusPrismaMethods[TypeName]
+  : <CustomTypeName extends keyof ModelTypes>(typeName: CustomTypeName) => NexusPrismaMethods[CustomTypeName]
+
+type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud'> =
+  ModelOrCrud extends 'model'
+    ? TypeName extends 'Mutation'
+      ? never
+      : TypeName extends 'Query'
+        ? never
+        : GetNexusPrismaMethod<TypeName>
+    : ModelOrCrud extends 'crud'
+      ? TypeName extends 'Mutation'
+        ? GetNexusPrismaMethod<TypeName>
+        : TypeName extends 'Query'
+          ? GetNexusPrismaMethod<TypeName>
+          : never
+      : never
+
+// Generated
+interface ModelTypes {
+  User: prisma.User
+}
+  
+interface NexusPrismaInputs {
+  Query: {
+    users: {
+  filtering: 'id' | 'date' | 'json' | 'AND' | 'OR' | 'NOT'
+  ordering: 'id' | 'date' | 'json'
+}
+
+  },
+    User: {
+
+
+  }
+}
+
+interface NexusPrismaTypes {
+  Query: {
+    user: 'User'
+    users: 'User'
+
+  },
+  Mutation: {
+    createOneUser: 'User'
+    updateOneUser: 'User'
+    updateManyUser: 'BatchPayload'
+    deleteOneUser: 'User'
+    deleteManyUser: 'BatchPayload'
+    upsertOneUser: 'User'
+
+  },
+  User: {
+    id: 'Int'
+    date: 'DateTime'
+    json: 'Json'
+
+}
+}
+
+interface NexusPrismaMethods {
+  User: NexusPrismaFields<'User'>
+  Query: NexusPrismaFields<'Query'>
+  Mutation: NexusPrismaFields<'Mutation'>
+}
+  
+
+declare global {
+  type NexusPrisma<
+    TypeName extends string,
+    ModelOrCrud extends 'model' | 'crud'
+  > = GetNexusPrisma<TypeName, ModelOrCrud>;
+}
+  "
+`;

--- a/tests/schema/__snapshots__/scalars.test.ts.snap
+++ b/tests/schema/__snapshots__/scalars.test.ts.snap
@@ -13,6 +13,7 @@ type User {
   id: Int!
   date: DateTime!
   json: Json!
+  optionalJson: Json
 }
 "
 `;
@@ -275,8 +276,8 @@ interface ModelTypes {
 interface NexusPrismaInputs {
   Query: {
     users: {
-  filtering: 'id' | 'date' | 'json' | 'AND' | 'OR' | 'NOT'
-  ordering: 'id' | 'date' | 'json'
+  filtering: 'id' | 'date' | 'json' | 'optionalJson' | 'AND' | 'OR' | 'NOT'
+  ordering: 'id' | 'date' | 'json' | 'optionalJson'
 }
 
   },
@@ -305,6 +306,7 @@ interface NexusPrismaTypes {
     id: 'Int'
     date: 'DateTime'
     json: 'Json'
+    optionalJson: 'Json'
 
 }
 }

--- a/tests/schema/scalars.test.ts
+++ b/tests/schema/scalars.test.ts
@@ -13,6 +13,7 @@ it('publishes date and json scalar output types', async () => {
     id  Int @id @default(autoincrement())
     date DateTime
     json Json
+    optionalJson Json?
   }
   `
 
@@ -22,6 +23,7 @@ it('publishes date and json scalar output types', async () => {
       t.model.id()
       t.model.date()
       t.model.json()
+      t.model.optionalJson()
     },
   })
 

--- a/tests/schema/scalars.test.ts
+++ b/tests/schema/scalars.test.ts
@@ -1,0 +1,38 @@
+import * as Nexus from '@nexus/schema'
+import { generateSchemaAndTypes } from '../__utils'
+
+it('publishes date and json scalar output types', async () => {
+  // datasource defined to postgres to enable Json type
+  const datamodel = `
+  datasource db {
+    provider = "postgresql"
+    url      = "postgresql://"
+  }
+
+  model User {
+    id  Int @id @default(autoincrement())
+    date DateTime
+    json Json
+  }
+  `
+
+  const User = Nexus.objectType({
+    name: 'User',
+    definition(t: any) {
+      t.model.id()
+      t.model.date()
+      t.model.json()
+    },
+  })
+
+  const {
+    schemaString,
+    schema,
+    typegen,
+  } = await generateSchemaAndTypes(datamodel, [User])
+
+  expect(schema.getType('Json')).not.toEqual(undefined)
+  expect(schema.getType('DateTime')).not.toEqual(undefined)
+  expect(schemaString).toMatchSnapshot('schema')
+  expect(typegen).toMatchSnapshot('typegen')
+})


### PR DESCRIPTION
This PR fixes #680 and #666

It **does not** add support for JSON filtering as this hasn't been implemented in Prisma yet. It removes the types and args entirely from the schema instead.