### PR TITLE
feat: warn if t.crud is used but not enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { plugin } from '@nexus/schema'
 import { build as buildNexusPrismaTypes, Options } from './builder'
+import { colors } from './colors'
 
 /**
  * Create a nexus-prisma plugin to be passed into the Nexus plugins array.
@@ -36,14 +37,34 @@ import { build as buildNexusPrismaTypes, Options } from './builder'
  * class support for typegen.
  */
 export function nexusPrismaPlugin(options?: Options) {
+  let wasCrudUsedButDisabled: null | (() => boolean) = null
+
   return plugin({
     name: 'nexus-prisma',
     onInstall: nexusBuilder => {
+      const {
+        types,
+        wasCrudUsedButDisabled: wasCrudUsed,
+      } = buildNexusPrismaTypes({
+        ...options,
+        nexusBuilder,
+      })
+
+      wasCrudUsedButDisabled = wasCrudUsed
+
       return {
-        types: buildNexusPrismaTypes({
-          ...options,
-          nexusBuilder,
-        }),
+        types,
+      }
+    },
+    onBeforeBuild() {
+      if (wasCrudUsedButDisabled?.() === true) {
+        console.log(`\
+${colors.yellow('Warning')}: ${colors.green(
+          't.crud',
+        )} ${colors.yellow('is an experimental feature that may evolve and break in the future. It must be explicitely enabled to be used.')}
+Please add ${colors.green(`experimentalCRUD: true`)} in the ${colors.green(
+          'nexusPluginPrisma()',
+        )} if you still wish to enable it.`)
       }
     },
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ ${colors.yellow('Warning')}: ${colors.green(
         )} ${colors.yellow('is an experimental feature with many practical limitations. You must explicitly enable it before using.')}
 Please add ${colors.green(`experimentalCRUD: true`)} in the ${colors.green(
           'nexusPluginPrisma()',
-        )} if you still wish to enable it.`)
+        )} constructor if you still wish to enable it.`)
       }
     },
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export function nexusPrismaPlugin(options?: Options) {
         console.log(`\
 ${colors.yellow('Warning')}: ${colors.green(
           't.crud',
-        )} ${colors.yellow('is an experimental feature that may evolve and break in the future. It must be explicitely enabled to be used.')}
+        )} ${colors.yellow('is an experimental feature with many practical limitations. You must explicitly enable it before using.')}
 Please add ${colors.green(`experimentalCRUD: true`)} in the ${colors.green(
           'nexusPluginPrisma()',
         )} if you still wish to enable it.`)

--- a/tests/__utils.ts
+++ b/tests/__utils.ts
@@ -15,7 +15,7 @@ export const createNexusPrismaInternal = (
   Nexus.createPlugin({
     name: 'nexus-prisma-internal',
     onInstall: nexusBuilder => ({
-      types: NexusPrismaBuilder.build({ ...options, nexusBuilder }),
+      types: NexusPrismaBuilder.build({ ...options, nexusBuilder }).types,
     }),
   })
 


### PR DESCRIPTION
This PR adds a warning for existing users who used to be able to use `t.crud` without enabling any flag.