### PR TITLE
fix: convert nulls to undefined for non-nullable Prisma fields

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -26,6 +26,7 @@ import {
   FieldNamingStrategy,
   OperationName,
 } from './naming-strategies'
+import { transformNullsToUndefined } from './null'
 import { proxifyModelFunction, proxifyPublishers } from './proxifier'
 import { Publisher } from './publisher'
 import * as Typegen from './typegen'
@@ -33,6 +34,7 @@ import {
   assertPhotonInContext,
   GlobalComputedInputs,
   Index,
+  indexBy,
   isEmptyObject,
   LocalComputedInputs,
   lowerFirst,
@@ -313,6 +315,7 @@ export class SchemaBuilder {
                 field: mappedField.field,
                 givenConfig: givenConfig ? givenConfig : {},
               })
+              const schemaArgsIndex = indexBy(mappedField.field.args, 'name')
 
               const originalResolve: GraphQLFieldResolver<any, any, any> = (
                 _root,
@@ -326,6 +329,7 @@ export class SchemaBuilder {
                   (!isEmptyObject(publisherConfig.locallyComputedInputs) ||
                     !isEmptyObject(this.globallyComputedInputs))
                 ) {
+                  args = transformNullsToUndefined(args, schemaArgsIndex, this.dmmf)
                   args = addComputedInputs({
                     inputType,
                     dmmf: this.dmmf,
@@ -521,6 +525,7 @@ export class SchemaBuilder {
           typeName,
           this.dmmf,
         )
+        const schemaArgsIndex = indexBy(field.args, 'name')
 
         const originalResolve: GraphQLFieldResolver<any, any, any> | undefined =
           field.outputType.kind === 'object'
@@ -541,6 +546,8 @@ export class SchemaBuilder {
                 }
 
                 const photon = this.getPrismaClient(ctx)
+
+                args = transformNullsToUndefined(args, schemaArgsIndex, this.dmmf)
 
                 return photon[lowerFirst(mapping.model)]
                   .findOne({

--- a/src/dmmf/DmmfTypes.ts
+++ b/src/dmmf/DmmfTypes.ts
@@ -57,6 +57,7 @@ export declare namespace DmmfTypes {
     inputType: {
       isRequired: boolean
       isList: boolean
+      isNullable: boolean
       type: ArgType
       kind: FieldKind
     }

--- a/src/null.ts
+++ b/src/null.ts
@@ -1,0 +1,46 @@
+import { DmmfDocument, DmmfTypes } from './dmmf'
+
+/**
+ * Take the incoming GraphQL args of a resolver and replaces all `null` values
+ * that maps to a non-nullable field in the Prisma Schema, by `undefined` values.
+ * 
+ * In Prisma, a `null` value has a specific meaning for the underlying database.
+ * Therefore, `undefined` is used instead to express the optionality of a field.
+ * 
+ * In GraphQL however, no difference is made between `null` and `undefined`.
+ * This is the reason why we need to convert all `null` values that were assigned to `non-nullable` fields to `undefined`.
+ */
+export function transformNullsToUndefined(
+  args: Record<string, any>,
+  schemaArgs: Record<string, DmmfTypes.SchemaArg>,
+  dmmf: DmmfDocument,
+) {
+  const keys = Object.keys(args)
+  for (const key of keys) {
+    const val = args[key]
+    const schemaArg = schemaArgs[key]
+
+    if (!schemaArg) {
+      throw new Error(`Could not find schema arg with name: ${key}`)
+    }
+
+    const shouldConvertNullToUndefined =
+      val === null && schemaArg.inputType.isNullable === false
+
+    if (shouldConvertNullToUndefined) {
+      args[key] = undefined
+    } else if (isObject(val)) {
+      const newSchemaArgs = dmmf.getInputTypeWithIndexedFields(
+        schemaArg.inputType.type,
+      ).fields
+
+      args[key] = transformNullsToUndefined(args[key], newSchemaArgs, dmmf)
+    }
+  }
+
+  return args
+}
+
+function isObject(obj: any): boolean {
+  return obj && typeof obj === 'object'
+}

--- a/src/null.ts
+++ b/src/null.ts
@@ -11,34 +11,34 @@ import { DmmfDocument, DmmfTypes } from './dmmf'
  * This is the reason why we need to convert all `null` values that were assigned to `non-nullable` fields to `undefined`.
  */
 export function transformNullsToUndefined(
-  args: Record<string, any>,
-  schemaArgs: Record<string, DmmfTypes.SchemaArg>,
+  graphqlArgs: Record<string, any>,
+  prismaArgs: Record<string, DmmfTypes.SchemaArg>,
   dmmf: DmmfDocument,
 ) {
-  const keys = Object.keys(args)
+  const keys = Object.keys(graphqlArgs)
   for (const key of keys) {
-    const val = args[key]
-    const schemaArg = schemaArgs[key]
+    const val = graphqlArgs[key]
+    const prismaArg = prismaArgs[key]
 
-    if (!schemaArg) {
+    if (!prismaArg) {
       throw new Error(`Could not find schema arg with name: ${key}`)
     }
 
     const shouldConvertNullToUndefined =
-      val === null && schemaArg.inputType.isNullable === false
+      val === null && prismaArg.inputType.isNullable === false
 
     if (shouldConvertNullToUndefined) {
-      args[key] = undefined
+      graphqlArgs[key] = undefined
     } else if (isObject(val)) {
-      const newSchemaArgs = dmmf.getInputTypeWithIndexedFields(
-        schemaArg.inputType.type,
+      const nestedPrismaArgs = dmmf.getInputTypeWithIndexedFields(
+        prismaArg.inputType.type,
       ).fields
 
-      args[key] = transformNullsToUndefined(args[key], newSchemaArgs, dmmf)
+      graphqlArgs[key] = transformNullsToUndefined(graphqlArgs[key], nestedPrismaArgs, dmmf)
     }
   }
 
-  return args
+  return graphqlArgs
 }
 
 function isObject(obj: any): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,8 +50,8 @@ export const hardWriteFileSync = (filePath: string, data: string): void => {
  * TODO
  */
 export const indexBy = <X extends Record<string, any>>(
-  indexer: ((x: X) => string) | keyof X,
   xs: X[],
+  indexer: ((x: X) => string) | keyof X,
 ): Index<X> => {
   const seed: Index<X> = {}
   if (typeof indexer === 'function') {

--- a/tests/runtime/__snapshots__/null.test.ts.snap
+++ b/tests/runtime/__snapshots__/null.test.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create: converts nulls to undefined when fields are not nullable 1`] = `
+Object {
+  "data": Object {
+    "id": undefined,
+    "posts": Object {
+      "connect": undefined,
+      "create": Object {
+        "id": "titi",
+      },
+    },
+  },
+}
+`;
+
+exports[`findMany: converts nulls to undefined when fields are not nullable 1`] = `
+Object {
+  "cursor": undefined,
+  "orderBy": Object {
+    "birthDate": null,
+    "email": null,
+    "id": "asc",
+  },
+  "skip": undefined,
+  "take": 1,
+  "where": Object {
+    "AND": undefined,
+    "NOT": Object {
+      "AND": Object {
+        "birthDate": undefined,
+      },
+      "posts": null,
+    },
+  },
+}
+`;
+
+exports[`model filtering: converts nulls to undefined when fields are not nullable 1`] = `
+Object {
+  "where": Object {
+    "authors": Object {
+      "every": Object {
+        "birthDate": undefined,
+        "email": null,
+        "posts": null,
+      },
+    },
+    "id": undefined,
+  },
+}
+`;

--- a/tests/runtime/__snapshots__/null.test.ts.snap
+++ b/tests/runtime/__snapshots__/null.test.ts.snap
@@ -16,14 +16,14 @@ Object {
 
 exports[`findMany: converts nulls to undefined when fields are not nullable 1`] = `
 Object {
-  "cursor": undefined,
+  "after": undefined,
+  "before": undefined,
+  "first": 1,
   "orderBy": Object {
     "birthDate": null,
     "email": null,
     "id": "asc",
   },
-  "skip": undefined,
-  "take": 1,
   "where": Object {
     "AND": undefined,
     "NOT": Object {

--- a/tests/runtime/null.test.ts
+++ b/tests/runtime/null.test.ts
@@ -57,9 +57,9 @@ test('findMany: converts nulls to undefined when fields are not nullable', async
   `
   const { dmmf, schemaArgs } = await getSchemaArgsForCrud(datamodel, 'User', 'findMany')
   const incomingArgs = {
-    cursor: null, // not nullable
-    skip: null, // not nullable
-    take: 1,
+    before: null, // not nullable
+    after: null, // not nullable
+    first: 1,
     orderBy: {
       email: null, // nullable
       birthDate: null, // nullable

--- a/tests/runtime/null.test.ts
+++ b/tests/runtime/null.test.ts
@@ -1,0 +1,149 @@
+import { DmmfTypes, DmmfDocument } from '../../src/dmmf'
+import { getCrudMappedFields } from '../../src/mapping'
+import { OperationName } from '../../src/naming-strategies'
+import { transformNullsToUndefined } from '../../src/null'
+import { indexBy } from '../../src/utils'
+import { getDmmf } from '../__utils'
+
+const operationToRoot: Record<OperationName, 'Query' | 'Mutation'> = {
+  findOne: 'Query',
+  findMany: 'Query',
+  create: 'Mutation',
+  delete: 'Mutation',
+  deleteMany: 'Mutation',
+  update: 'Mutation',
+  updateMany: 'Mutation',
+  upsert: 'Mutation'
+}
+
+async function getSchemaArgsForCrud(
+  datamodel: string,
+  model: string,
+  operation: OperationName,
+): Promise<{
+  schemaArgs: Record<string, DmmfTypes.SchemaArg>
+  dmmf: DmmfDocument
+}> {
+  const dmmf = await getDmmf(datamodel)
+  const mappedField = getCrudMappedFields(operationToRoot[operation], dmmf).find(
+    x => x.operation === operation && x.model === model,
+  )
+
+  if (!mappedField) {
+    throw new Error(
+      `Could not find mapped fields for model ${model} and operation ${operation}`,
+    )
+  }
+
+  return {
+    schemaArgs: indexBy(mappedField.field.args, 'name'),
+    dmmf,
+  }
+}
+
+test('findMany: converts nulls to undefined when fields are not nullable', async () => {
+  const datamodel = `
+  model User {
+    id        String   @default(cuid()) @id
+    email     String?  @unique
+    birthDate DateTime
+    posts     Post[]
+  }
+  
+  model Post {
+    id      String @default(cuid()) @id
+    authors User[] @relation(references: [id])
+  }
+  `
+  const { dmmf, schemaArgs } = await getSchemaArgsForCrud(datamodel, 'User', 'findMany')
+  const incomingArgs = {
+    cursor: null, // not nullable
+    skip: null, // not nullable
+    take: 1,
+    orderBy: {
+      email: null, // nullable
+      birthDate: null, // nullable
+      id: 'asc',
+    },
+    where: {
+      AND: null, // not nullable
+      NOT: {
+        AND: {
+          birthDate: null, // not nullable
+        },
+        posts: null,
+      },
+    },
+  }
+
+  const result = transformNullsToUndefined(incomingArgs, schemaArgs, dmmf)
+
+  expect(result).toMatchSnapshot()
+})
+
+test('create: converts nulls to undefined when fields are not nullable', async () => {
+  const datamodel = `
+  model User {
+    id        String   @default(cuid()) @id
+    email     String?  @unique
+    birthDate DateTime
+    posts     Post[]
+  }
+  
+  model Post {
+    id      String @default(cuid()) @id
+    authors User[] @relation(references: [id])
+  }
+  `
+  const { dmmf, schemaArgs } = await getSchemaArgsForCrud(datamodel, 'User', 'create')
+  const incomingArgs = {
+    data: {
+      id: null, // not nullable
+      posts: {
+        connect: null, // not nullable
+        create: {
+          id: 'titi',
+        },
+      },
+    },
+  }
+
+  const result = transformNullsToUndefined(incomingArgs, schemaArgs, dmmf)
+
+  expect(result).toMatchSnapshot()
+})
+
+test('model filtering: converts nulls to undefined when fields are not nullable', async () => {
+  const datamodel = `
+  model User {
+    id        String   @default(cuid()) @id
+    email     String?  @unique
+    birthDate DateTime
+    posts     Post[]
+  }
+  
+  model Post {
+    id      String @default(cuid()) @id
+    authors User[] @relation(references: [id])
+  }
+  `
+  const dmmf = await getDmmf(datamodel)
+  const schemaArgs = dmmf.getOutputType('User').fields.find(f => f.name === 'posts')?.args!
+  const indexedSchemaArgs = indexBy(schemaArgs, 'name')
+  const incomingArgs = {
+    where: {
+      id: null, // not nullable
+      authors: {
+        every: {
+          email: null,
+          birthDate: null, // not nullable
+          posts: null,
+        },
+      },
+    },
+  }
+
+  const result = transformNullsToUndefined(incomingArgs, indexedSchemaArgs, dmmf)
+
+  expect(result).toMatchSnapshot()
+})


### PR DESCRIPTION
Take the incoming GraphQL args of a resolver and replaces all `null` values
that maps to a non-nullable field in the Prisma Schema, by `undefined` values.

In Prisma, a `null` value has a specific meaning for the underlying database.
Therefore, `undefined` is used instead to express the optionality of a field.
 
In GraphQL however, no difference is made between `null` and `undefined`.
This is the reason why we need to convert all `null` values that were assigned to `non-nullable` fields to `undefined`.