### PR TITLE
feat: revert to old pagination model

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -36,6 +36,7 @@ import {
   LocalComputedInputs,
   lowerFirst,
 } from './utils'
+import { PaginationStrategy, relayLikePaginationStrategy } from './pagination'
 
 interface FieldPublisherConfig {
   alias?: string
@@ -77,7 +78,7 @@ type FieldConfigData = {
 
 /**
  * When dealing with list types we rely on the list type zero value (empty-list)
- * to represet the idea of null.
+ * to represent the idea of null.
  *
  * For Prisma Client JS' part, it will never return null for list type fields nor will it
  * ever return null value list members.
@@ -160,7 +161,7 @@ export function build(options: InternalOptions) {
   }
 }
 
-// The @types default is based on the priviledge given to such
+// The @types default is based on the privileged given to such
 // packages by TypeScript. For details refer to https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types
 let defaultTypegenPath: string
 if (process.env.NEXUS_PRISMA_TYPEGEN_PATH) {
@@ -187,7 +188,7 @@ if (process.env.NEXUS_PRISMA_CLIENT_PATH) {
   defaultClientPath = '@prisma/client'
 }
 
-// NOTE This will be repalced by Nexus plugins once typegen integration is available.
+// NOTE This will be replaced by Nexus plugins once typegen integration is available.
 const shouldGenerateArtifacts =
   process.env.NEXUS_SHOULD_GENERATE_ARTIFACTS === 'true'
     ? true
@@ -216,6 +217,7 @@ export class SchemaBuilder {
   readonly dmmf: DmmfDocument
   protected argsNamingStrategy: ArgsNamingStrategy
   protected fieldNamingStrategy: FieldNamingStrategy
+  protected paginationStrategy: PaginationStrategy
   protected getPrismaClient: PrismaClientFetcher
   protected publisher: Publisher
   protected globallyComputedInputs: GlobalComputedInputs
@@ -233,10 +235,12 @@ export class SchemaBuilder {
     this.globallyComputedInputs = config.computedInputs
       ? config.computedInputs
       : {}
+    this.paginationStrategy = relayLikePaginationStrategy
     this.dmmf =
       options.dmmf ||
       getTransformedDmmf(config.inputs.prismaClient, {
         globallyComputedInputs: this.globallyComputedInputs,
+        paginationStrategy: this.paginationStrategy,
       })
     this.publisher = new Publisher(this.dmmf, config.nexusBuilder)
     this.unknownFieldsByModel = {}
@@ -329,6 +333,9 @@ export class SchemaBuilder {
                       publisherConfig.locallyComputedInputs,
                   })
                 }
+
+                args = this.paginationStrategy.resolve(args)
+
                 return photon[mappedField.photonAccessor][
                   mappedField.operation
                 ](args)
@@ -536,6 +543,8 @@ export class SchemaBuilder {
 
                 const photon = this.getPrismaClient(ctx)
 
+                args = this.paginationStrategy.resolve(args)
+
                 return photon[lowerFirst(mapping.model)]
                   .findOne({
                     where: Constraints.buildWhereUniqueInput(
@@ -731,10 +740,11 @@ export class SchemaBuilder {
     }
 
     if (publisherConfig.pagination) {
-      const paginationKeys = ['cursor', 'take', 'skip']
       const paginationsArgs =
         publisherConfig.pagination === true
-          ? field.args.filter(a => paginationKeys.includes(a.name))
+          ? field.args.filter(a =>
+              this.paginationStrategy.paginationArgNames.includes(a.name),
+            )
           : field.args.filter(
               arg => (publisherConfig.pagination as any)[arg.name] === true,
             )
@@ -762,7 +772,7 @@ export class SchemaBuilder {
   /**
    * This handles "tailored field feature publishing".
    *
-   * With tailord field feature publishing, users can specify that only some
+   * With tailored field feature publishing, users can specify that only some
    * fields of the PSL model are exposed under the given field feature. For
    * example, in the following...
    *

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -258,6 +258,7 @@ export class SchemaBuilder {
       Typegen.generateSync({
         prismaClientPath: config.inputs.prismaClient,
         typegenPath: config.outputs.typegen,
+        paginationStrategy: this.paginationStrategy,
       })
     }
   }

--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -11,7 +11,7 @@ import { PaginationStrategy, relayLikePaginationStrategy } from '../pagination'
 
 export type TransformOptions = {
   globallyComputedInputs?: GlobalComputedInputs
-  paginationStrategy?: PaginationStrategy<any>
+  paginationStrategy?: PaginationStrategy
 }
 
 export const getTransformedDmmf = (

--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -7,9 +7,11 @@ import {
 import { getPhotonDmmf } from './utils'
 import { DmmfDocument } from './DmmfDocument'
 import { DmmfTypes } from './DmmfTypes'
+import { PaginationStrategy, relayLikePaginationStrategy } from '../pagination'
 
 export type TransformOptions = {
   globallyComputedInputs?: GlobalComputedInputs
+  paginationStrategy?: PaginationStrategy<any>
 }
 
 export const getTransformedDmmf = (
@@ -22,6 +24,7 @@ const addDefaultOptions = (
   givenOptions?: TransformOptions,
 ): Required<TransformOptions> => ({
   globallyComputedInputs: {},
+  paginationStrategy: relayLikePaginationStrategy,
   ...givenOptions,
 })
 
@@ -49,32 +52,54 @@ function transformDatamodel(datamodel: DMMF.Datamodel): DmmfTypes.Datamodel {
   }
 }
 
+const paginationArgNames = ['cursor', 'take', 'skip']
+
 function transformSchema(
   schema: DMMF.Schema,
-  { globallyComputedInputs }: Required<TransformOptions>,
+  { globallyComputedInputs, paginationStrategy }: Required<TransformOptions>,
 ): DmmfTypes.Schema {
   return {
     enums: schema.enums,
     inputTypes: schema.inputTypes.map(_ =>
       transformInputType(_, globallyComputedInputs),
     ),
-    outputTypes: schema.outputTypes.map(o => ({
-      ...o,
-      fields: o.fields.map(f => ({
-        ...f,
-        args: f.args.map(transformArg),
-        outputType: {
-          ...f.outputType,
-          type: getReturnTypeName(f.outputType.type),
-        },
-      })),
-    })),
+    outputTypes: schema.outputTypes.map(o => {
+      return {
+        ...o,
+        fields: o.fields.map(f => {
+          let args = f.args.map(transformArg)
+          const argNames = args.map(a => a.name)
+
+          // If this field has pagination
+          if (
+            paginationArgNames.every(paginationArgName =>
+              argNames.includes(paginationArgName),
+            )
+          ) {
+            args = paginationStrategy.transformDmmfArgs({
+              args,
+              paginationArgNames,
+              field: f,
+            })
+          }
+
+          return {
+            ...f,
+            args,
+            outputType: {
+              ...f.outputType,
+              type: getReturnTypeName(f.outputType.type),
+            },
+          }
+        }),
+      }
+    }),
   }
 }
 
 /**
- * Conversion from a Photon arg type to a GraphQL arg type using
- * heuristics. A conversion is needed becuase GraphQL does not
+ * Conversion from a Prisma Client arg type to a GraphQL arg type using
+ * heuristics. A conversion is needed because GraphQL does not
  * support union types on args, but Photon does.
  */
 function transformArg(arg: DMMF.SchemaArg): DmmfTypes.SchemaArg {
@@ -230,10 +255,10 @@ function transformInputType(
 //
 // TODO _why_ is the dmmf like this?
 //
-// FIXME `any` type becuase this is used by both outputType and inputType
+// FIXME `any` type because this is used by both outputType and inputType
 // and there is currently no generic capturing both ideas.
 //
-function getReturnTypeName(type: any) {
+export function getReturnTypeName(type: any): string {
   if (typeof type === 'string') {
     return type
   }

--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -88,7 +88,7 @@ function transformSchema(
             args,
             outputType: {
               ...f.outputType,
-              type: getReturnTypeName(f.outputType.type),
+              type: getReturnTypeName(f.outputType.type) as any,
             },
           }
         }),

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -10,13 +10,13 @@ interface PaginationResult {
 }
 
 export interface PaginationStrategy<T = object> {
-  transformDmmfArgs: (params: {
+  paginationArgNames: string[]
+  transformDmmfArgs(params: {
     args: DmmfTypes.SchemaArg[]
     paginationArgNames: string[]
     field: DMMF.SchemaField
-  }) => DmmfTypes.SchemaArg[]
-  paginationArgNames: string[]
-  resolve: (args: T) => PaginationResult
+  }): DmmfTypes.SchemaArg[]
+  resolve(args: T): PaginationResult
 }
 
 const relayLikePaginationArgs: Record<

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,7 +1,7 @@
 import { DmmfTypes, getReturnTypeName } from './dmmf'
 import { DMMF } from '@prisma/client/runtime'
 
-export interface PaginationStrategy<T = any> {
+export interface PaginationStrategy<T = object> {
   transformDmmfArgs: (params: {
     args: DmmfTypes.SchemaArg[]
     paginationArgNames: string[]
@@ -71,13 +71,15 @@ const relayLikePaginationArgs: Record<
   }),
 }
 
-export const relayLikePaginationStrategy: PaginationStrategy<{
+interface RelayLikePaginationArgs {
   first?: number
   last?: number
   skip?: number
   before?: object
   after?: object
-}> = {
+}
+
+export const relayLikePaginationStrategy: PaginationStrategy<RelayLikePaginationArgs> = {
   paginationArgNames: Object.keys(relayLikePaginationArgs),
   transformDmmfArgs({ args, paginationArgNames, field }) {
     const fieldOutputTypeName = getReturnTypeName(field.outputType.type)

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,0 +1,172 @@
+import { DmmfTypes, getReturnTypeName } from './dmmf'
+import { DMMF } from '@prisma/client/runtime'
+
+export interface PaginationStrategy<T = any> {
+  transformDmmfArgs: (params: {
+    args: DmmfTypes.SchemaArg[]
+    paginationArgNames: string[]
+    field: DMMF.SchemaField
+  }) => DmmfTypes.SchemaArg[]
+  paginationArgNames: string[]
+  resolve: (
+    args: T,
+  ) => { cursor?: object; skip?: string | number; take?: string | number } & {
+    [x: string]: any
+  }
+}
+
+const relayLikePaginationArgs: Record<
+  'first' | 'last' | 'skip' | 'before' | 'after',
+  (typeName: string) => DmmfTypes.SchemaArg
+> = {
+  first: () => ({
+    name: 'first',
+    inputType: {
+      type: 'Int',
+      kind: 'scalar',
+      isRequired: false,
+      isList: false,
+      isNullable: false,
+    },
+  }),
+  last: () => ({
+    name: 'last',
+    inputType: {
+      type: 'Int',
+      kind: 'scalar',
+      isRequired: false,
+      isList: false,
+      isNullable: false,
+    },
+  }),
+  skip: () => ({
+    name: 'skip',
+    inputType: {
+      type: 'Int',
+      kind: 'scalar',
+      isRequired: false,
+      isList: false,
+      isNullable: false,
+    },
+  }),
+  before: (typeName: string) => ({
+    name: 'before',
+    inputType: {
+      type: `${typeName}WhereUniqueInput`,
+      kind: 'object',
+      isRequired: false,
+      isList: false,
+      isNullable: false,
+    },
+  }),
+  after: (typeName: string) => ({
+    name: 'after',
+    inputType: {
+      type: `${typeName}WhereUniqueInput`,
+      kind: 'object',
+      isRequired: false,
+      isList: false,
+      isNullable: false,
+    },
+  }),
+}
+
+export const relayLikePaginationStrategy: PaginationStrategy<{
+  first?: number
+  last?: number
+  skip?: number
+  before?: object
+  after?: object
+}> = {
+  paginationArgNames: Object.keys(relayLikePaginationArgs),
+  transformDmmfArgs({ args, paginationArgNames, field }) {
+    const fieldOutputTypeName = getReturnTypeName(field.outputType.type)
+
+    // Remove old pagination args
+    args = args.filter(a => !paginationArgNames.includes(a.name))
+
+    // Push new pagination args
+    args.push(
+      relayLikePaginationArgs.first(fieldOutputTypeName),
+      relayLikePaginationArgs.last(fieldOutputTypeName),
+      relayLikePaginationArgs.before(fieldOutputTypeName),
+      relayLikePaginationArgs.after(fieldOutputTypeName),
+      relayLikePaginationArgs.skip(fieldOutputTypeName),
+    )
+
+    return args
+  },
+  resolve(args) {
+    const { first, last, before, after, skip: originalSkip } = args
+
+    if (!first && !last && !before && !after) {
+      return args
+    }
+
+    const take = resolveTake(first, last)
+    const cursor = resolveCursor(before, after)
+    const skip = resolveSkip(originalSkip, cursor)
+
+    delete args.first
+    delete args.last
+    delete args.before
+    delete args.after
+
+    const newArgs = {
+      ...args,
+      take,
+      cursor,
+      skip,
+    }
+
+    console.log('pagination args', newArgs)
+
+    return newArgs
+  },
+}
+
+function resolveSkip(skip: number | undefined, cursor: object | undefined) {
+  if (!skip) {
+    return undefined
+  }
+
+  if (cursor) {
+    return skip + 1
+  }
+
+  return skip
+}
+
+function resolveTake(
+  first: number | undefined,
+  last: number | undefined,
+): number | undefined {
+  if (first && last) {
+    throw new Error(`first and last can't be set simultaneously`)
+  }
+
+  if (first) {
+    if (first < 0) {
+      throw new Error(`first can't be negative`)
+    }
+    return first
+  }
+
+  if (last) {
+    if (last < 0) {
+      throw new Error(`last can't be negative`)
+    }
+
+    return last * -1
+  }
+
+  return undefined
+}
+
+function resolveCursor(before: object | undefined, after: object | undefined) {
+  if (before && after) {
+    throw new Error(`before and after can't be set simultaneously`)
+  }
+
+  return before ?? after
+}

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -246,9 +246,10 @@ function renderStaticTypes() {
     } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
 
     type Pagination = {
-      skip?: boolean
-      take?: boolean
-      cursor?: boolean
+      first?: boolean
+      last?: boolean
+      before?: boolean
+      after?: boolean
     }
 
     type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>

--- a/tests/__app/generated/nexus-prisma-typegen.d.ts
+++ b/tests/__app/generated/nexus-prisma-typegen.d.ts
@@ -22,12 +22,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
 
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
-
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
 /**
@@ -246,6 +240,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {

--- a/tests/__app/generated/nexus-prisma-typegen.d.ts
+++ b/tests/__app/generated/nexus-prisma-typegen.d.ts
@@ -245,7 +245,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }

--- a/tests/__app/generated/nexus-typegen.d.ts
+++ b/tests/__app/generated/nexus-typegen.d.ts
@@ -274,7 +274,6 @@ export interface NexusGenArgTypes {
       before?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
       first?: number | null; // Int
       last?: number | null; // Int
-      skip?: number | null; // Int
     }
   }
   User: {
@@ -284,7 +283,6 @@ export interface NexusGenArgTypes {
       first?: number | null; // Int
       last?: number | null; // Int
       orderBy?: NexusGenInputs['PostOrderByInput'] | null; // PostOrderByInput
-      skip?: number | null; // Int
       where?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
     }
   }

--- a/tests/__app/generated/nexus-typegen.d.ts
+++ b/tests/__app/generated/nexus-typegen.d.ts
@@ -251,7 +251,7 @@ export interface NexusGenFieldTypes {
 export interface NexusGenArgTypes {
   Bubble: {
     members: { // args
-      cursor?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
+      after?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
       orderBy?: NexusGenInputs['BubbleMembersOrderByInput'] | null; // BubbleMembersOrderByInput
       where?: NexusGenInputs['BubbleMembersWhereInput'] | null; // BubbleMembersWhereInput
     }
@@ -270,17 +270,21 @@ export interface NexusGenArgTypes {
       where: NexusGenInputs['UserWhereUniqueInput']; // UserWhereUniqueInput!
     }
     users: { // args
-      cursor?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
+      after?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
+      before?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
+      first?: number | null; // Int
+      last?: number | null; // Int
       skip?: number | null; // Int
-      take?: number | null; // Int
     }
   }
   User: {
     posts: { // args
-      cursor?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
+      after?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
+      before?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
+      first?: number | null; // Int
+      last?: number | null; // Int
       orderBy?: NexusGenInputs['PostOrderByInput'] | null; // PostOrderByInput
       skip?: number | null; // Int
-      take?: number | null; // Int
       where?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
     }
   }

--- a/tests/__app/generated/schema.graphql
+++ b/tests/__app/generated/schema.graphql
@@ -152,7 +152,7 @@ input PostWhereUniqueInput {
 
 type Query {
   user(where: UserWhereUniqueInput!): User
-  users(after: UserWhereUniqueInput, before: UserWhereUniqueInput, first: Int, last: Int, skip: Int): [User!]!
+  users(after: UserWhereUniqueInput, before: UserWhereUniqueInput, first: Int, last: Int): [User!]!
 }
 
 input StringFilter {
@@ -172,7 +172,7 @@ input StringFilter {
 type User {
   firstName: String!
   id: String!
-  posts(after: PostWhereUniqueInput, before: PostWhereUniqueInput, first: Int, last: Int, orderBy: PostOrderByInput, skip: Int, where: PostWhereInput): [Post!]!
+  posts(after: PostWhereUniqueInput, before: PostWhereUniqueInput, first: Int, last: Int, orderBy: PostOrderByInput, where: PostWhereInput): [Post!]!
 }
 
 input UserCreateManyWithoutPostsInput {

--- a/tests/__app/generated/schema.graphql
+++ b/tests/__app/generated/schema.graphql
@@ -9,7 +9,7 @@ type BatchPayload {
 type Bubble {
   createdAt: DateTime!
   id: String!
-  members(cursor: UserWhereUniqueInput, orderBy: BubbleMembersOrderByInput, where: BubbleMembersWhereInput): [User!]!
+  members(after: UserWhereUniqueInput, orderBy: BubbleMembersOrderByInput, where: BubbleMembersWhereInput): [User!]!
 }
 
 input BubbleCreateOneWithoutMembersInput {
@@ -152,7 +152,7 @@ input PostWhereUniqueInput {
 
 type Query {
   user(where: UserWhereUniqueInput!): User
-  users(cursor: UserWhereUniqueInput, skip: Int, take: Int): [User!]!
+  users(after: UserWhereUniqueInput, before: UserWhereUniqueInput, first: Int, last: Int, skip: Int): [User!]!
 }
 
 input StringFilter {
@@ -172,7 +172,7 @@ input StringFilter {
 type User {
   firstName: String!
   id: String!
-  posts(cursor: PostWhereUniqueInput, orderBy: PostOrderByInput, skip: Int, take: Int, where: PostWhereInput): [Post!]!
+  posts(after: PostWhereUniqueInput, before: PostWhereUniqueInput, first: Int, last: Int, orderBy: PostOrderByInput, skip: Int, where: PostWhereInput): [Post!]!
 }
 
 input UserCreateManyWithoutPostsInput {

--- a/tests/__app/main.ts
+++ b/tests/__app/main.ts
@@ -47,7 +47,7 @@ export const Bubble = objectType({
     t.model.createdAt()
     // ASSERT filtering & ordering & pagination for only certain properties
     t.model.members({
-      pagination: { after: true, skip: false },
+      pagination: { after: true, first: false },
       filtering: { id: true },
       ordering: { firstName: true },
     })

--- a/tests/__app/main.ts
+++ b/tests/__app/main.ts
@@ -47,7 +47,7 @@ export const Bubble = objectType({
     t.model.createdAt()
     // ASSERT filtering & ordering & pagination for only certain properties
     t.model.members({
-      pagination: { cursor: true, skip: false },
+      pagination: { after: true, skip: false },
       filtering: { id: true },
       ordering: { firstName: true },
     })

--- a/tests/__snapshots__/app.test.ts.snap
+++ b/tests/__snapshots__/app.test.ts.snap
@@ -14,7 +14,7 @@ type BatchPayload {
 type Bubble {
   createdAt: DateTime!
   id: String!
-  members(cursor: UserWhereUniqueInput, orderBy: BubbleMembersOrderByInput, where: BubbleMembersWhereInput): [User!]!
+  members(after: UserWhereUniqueInput, orderBy: BubbleMembersOrderByInput, where: BubbleMembersWhereInput): [User!]!
 }
 
 input BubbleCreateOneWithoutMembersInput {
@@ -157,7 +157,7 @@ input PostWhereUniqueInput {
 
 type Query {
   user(where: UserWhereUniqueInput!): User
-  users(cursor: UserWhereUniqueInput, skip: Int, take: Int): [User!]!
+  users(after: UserWhereUniqueInput, before: UserWhereUniqueInput, first: Int, last: Int, skip: Int): [User!]!
 }
 
 input StringFilter {
@@ -177,7 +177,7 @@ input StringFilter {
 type User {
   firstName: String!
   id: String!
-  posts(cursor: PostWhereUniqueInput, orderBy: PostOrderByInput, skip: Int, take: Int, where: PostWhereInput): [Post!]!
+  posts(after: PostWhereUniqueInput, before: PostWhereUniqueInput, first: Int, last: Int, orderBy: PostOrderByInput, skip: Int, where: PostWhereInput): [Post!]!
 }
 
 input UserCreateManyWithoutPostsInput {
@@ -470,7 +470,7 @@ export interface NexusGenFieldTypes {
 export interface NexusGenArgTypes {
   Bubble: {
     members: { // args
-      cursor?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
+      after?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
       orderBy?: NexusGenInputs['BubbleMembersOrderByInput'] | null; // BubbleMembersOrderByInput
       where?: NexusGenInputs['BubbleMembersWhereInput'] | null; // BubbleMembersWhereInput
     }
@@ -489,17 +489,21 @@ export interface NexusGenArgTypes {
       where: NexusGenInputs['UserWhereUniqueInput']; // UserWhereUniqueInput!
     }
     users: { // args
-      cursor?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
+      after?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
+      before?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
+      first?: number | null; // Int
+      last?: number | null; // Int
       skip?: number | null; // Int
-      take?: number | null; // Int
     }
   }
   User: {
     posts: { // args
-      cursor?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
+      after?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
+      before?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
+      first?: number | null; // Int
+      last?: number | null; // Int
       orderBy?: NexusGenInputs['PostOrderByInput'] | null; // PostOrderByInput
       skip?: number | null; // Int
-      take?: number | null; // Int
       where?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
     }
   }
@@ -578,12 +582,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   alias?: Alias
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
-
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
 
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
@@ -803,6 +801,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {

--- a/tests/__snapshots__/app.test.ts.snap
+++ b/tests/__snapshots__/app.test.ts.snap
@@ -157,7 +157,7 @@ input PostWhereUniqueInput {
 
 type Query {
   user(where: UserWhereUniqueInput!): User
-  users(after: UserWhereUniqueInput, before: UserWhereUniqueInput, first: Int, last: Int, skip: Int): [User!]!
+  users(after: UserWhereUniqueInput, before: UserWhereUniqueInput, first: Int, last: Int): [User!]!
 }
 
 input StringFilter {
@@ -177,7 +177,7 @@ input StringFilter {
 type User {
   firstName: String!
   id: String!
-  posts(after: PostWhereUniqueInput, before: PostWhereUniqueInput, first: Int, last: Int, orderBy: PostOrderByInput, skip: Int, where: PostWhereInput): [Post!]!
+  posts(after: PostWhereUniqueInput, before: PostWhereUniqueInput, first: Int, last: Int, orderBy: PostOrderByInput, where: PostWhereInput): [Post!]!
 }
 
 input UserCreateManyWithoutPostsInput {
@@ -493,7 +493,6 @@ export interface NexusGenArgTypes {
       before?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
       first?: number | null; // Int
       last?: number | null; // Int
-      skip?: number | null; // Int
     }
   }
   User: {
@@ -503,7 +502,6 @@ export interface NexusGenArgTypes {
       first?: number | null; // Int
       last?: number | null; // Int
       orderBy?: NexusGenInputs['PostOrderByInput'] | null; // PostOrderByInput
-      skip?: number | null; // Int
       where?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
     }
   }
@@ -806,7 +804,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }

--- a/tests/__utils.ts
+++ b/tests/__utils.ts
@@ -68,7 +68,11 @@ export async function generateSchemaAndTypes(
   return {
     schemaString: GQL.printSchema(schema),
     schema,
-    typegen: renderTypegen(dmmf, '@prisma/client', relayLikePaginationStrategy),
+    typegen: renderTypegen({
+      dmmf,
+      prismaClientPath: '@prisma/client',
+      paginationStrategy: relayLikePaginationStrategy,
+    }),
   }
 }
 
@@ -92,11 +96,11 @@ export async function generateSchemaAndTypesWithoutThrowing(
     types: [types, nexusPrisma],
     outputs: false,
   })
-  const typegen = renderTypegen(
+  const typegen = renderTypegen({
     dmmf,
-    '@prisma/client',
-    relayLikePaginationStrategy,
-  )
+    prismaClientPath: '@prisma/client',
+    paginationStrategy: relayLikePaginationStrategy,
+  })
 
   return {
     schema: GQL.printSchema(schemaAndMissingTypes.schema),

--- a/tests/__utils.ts
+++ b/tests/__utils.ts
@@ -8,6 +8,7 @@ import { DmmfDocument } from '../src/dmmf'
 import { transform, TransformOptions } from '../src/dmmf/transformer'
 import { render as renderTypegen } from '../src/typegen'
 import { getEnginePath } from './__ensure-engine'
+import { relayLikePaginationStrategy } from '../src/pagination'
 
 export const createNexusPrismaInternal = (
   options: Omit<NexusPrismaBuilder.InternalOptions, 'nexusBuilder'>,
@@ -67,7 +68,7 @@ export async function generateSchemaAndTypes(
   return {
     schemaString: GQL.printSchema(schema),
     schema,
-    typegen: renderTypegen(dmmf, '@prisma/client'),
+    typegen: renderTypegen(dmmf, '@prisma/client', relayLikePaginationStrategy),
   }
 }
 
@@ -91,7 +92,11 @@ export async function generateSchemaAndTypesWithoutThrowing(
     types: [types, nexusPrisma],
     outputs: false,
   })
-  const typegen = renderTypegen(dmmf, '@prisma/client')
+  const typegen = renderTypegen(
+    dmmf,
+    '@prisma/client',
+    relayLikePaginationStrategy,
+  )
 
   return {
     schema: GQL.printSchema(schemaAndMissingTypes.schema),

--- a/tests/schema/__snapshots__/computedInputs.test.ts.snap
+++ b/tests/schema/__snapshots__/computedInputs.test.ts.snap
@@ -38,7 +38,7 @@ type Query {
 type User {
   id: Int!
   name: String!
-  nested(cursor: NestedWhereUniqueInput, take: Int, skip: Int): [Nested!]!
+  nested(first: Int, last: Int, before: NestedWhereUniqueInput, after: NestedWhereUniqueInput, skip: Int): [Nested!]!
   createdWithBrowser: String!
 }
 
@@ -83,12 +83,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   alias?: Alias
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
-
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
 
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
@@ -308,6 +302,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {
@@ -444,12 +447,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
 
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
-
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
 /**
@@ -668,6 +665,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {

--- a/tests/schema/__snapshots__/computedInputs.test.ts.snap
+++ b/tests/schema/__snapshots__/computedInputs.test.ts.snap
@@ -38,7 +38,7 @@ type Query {
 type User {
   id: Int!
   name: String!
-  nested(first: Int, last: Int, before: NestedWhereUniqueInput, after: NestedWhereUniqueInput, skip: Int): [Nested!]!
+  nested(first: Int, last: Int, before: NestedWhereUniqueInput, after: NestedWhereUniqueInput): [Nested!]!
   createdWithBrowser: String!
 }
 
@@ -307,7 +307,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }
@@ -670,7 +669,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }

--- a/tests/schema/__snapshots__/crud.test.ts.snap
+++ b/tests/schema/__snapshots__/crud.test.ts.snap
@@ -36,12 +36,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
 
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
-
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
 /**
@@ -260,6 +254,14 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {

--- a/tests/schema/__snapshots__/enums.test.ts.snap
+++ b/tests/schema/__snapshots__/enums.test.ts.snap
@@ -7,7 +7,7 @@ exports[`does not automatically publish input/enum type if already created by us
 }
 
 type Query {
-  users(where: UserWhereInput, cursor: UserWhereUniqueInput, take: Int, skip: Int): [User!]!
+  users(where: UserWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput, skip: Int): [User!]!
 }
 
 type User {
@@ -49,12 +49,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   alias?: Alias
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
-
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
 
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
@@ -274,6 +268,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {
@@ -351,7 +354,7 @@ input IntFilter {
 }
 
 type Query {
-  users(where: UserWhereInput, cursor: UserWhereUniqueInput, take: Int, skip: Int): [User!]!
+  users(where: UserWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput, skip: Int): [User!]!
 }
 
 type User {
@@ -397,12 +400,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   alias?: Alias
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
-
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
 
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
@@ -622,6 +619,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {
@@ -723,12 +729,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
 
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
-
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
 /**
@@ -947,6 +947,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {

--- a/tests/schema/__snapshots__/enums.test.ts.snap
+++ b/tests/schema/__snapshots__/enums.test.ts.snap
@@ -7,7 +7,7 @@ exports[`does not automatically publish input/enum type if already created by us
 }
 
 type Query {
-  users(where: UserWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput, skip: Int): [User!]!
+  users(where: UserWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput): [User!]!
 }
 
 type User {
@@ -273,7 +273,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }
@@ -354,7 +353,7 @@ input IntFilter {
 }
 
 type Query {
-  users(where: UserWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput, skip: Int): [User!]!
+  users(where: UserWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput): [User!]!
 }
 
 type User {
@@ -624,7 +623,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }
@@ -952,7 +950,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }

--- a/tests/schema/__snapshots__/filtering-ordering.test.ts.snap
+++ b/tests/schema/__snapshots__/filtering-ordering.test.ts.snap
@@ -10,7 +10,7 @@ Warning: Your GraphQL \`Query\` object definition is projecting a relational fie
 
 exports[`in dev stage, removes filtering or ordering entirely if no arg or wrong args are passed and log error: schema 1`] = `
 "type Query {
-  users(first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput, skip: Int): [User!]!
+  users(first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput): [User!]!
 }
 
 type User {
@@ -272,7 +272,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }

--- a/tests/schema/__snapshots__/filtering-ordering.test.ts.snap
+++ b/tests/schema/__snapshots__/filtering-ordering.test.ts.snap
@@ -10,7 +10,7 @@ Warning: Your GraphQL \`Query\` object definition is projecting a relational fie
 
 exports[`in dev stage, removes filtering or ordering entirely if no arg or wrong args are passed and log error: schema 1`] = `
 "type Query {
-  users(cursor: UserWhereUniqueInput, take: Int, skip: Int): [User!]!
+  users(first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput, skip: Int): [User!]!
 }
 
 type User {
@@ -48,12 +48,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   alias?: Alias
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
-
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
 
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
@@ -273,6 +267,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {

--- a/tests/schema/__snapshots__/naming.test.ts.snap
+++ b/tests/schema/__snapshots__/naming.test.ts.snap
@@ -56,7 +56,7 @@ type Mutation {
 
 type Query {
   modelName(where: ModelNameWhereUniqueInput!): ModelName
-  modelNames(cursor: ModelNameWhereUniqueInput, take: Int, skip: Int): [ModelName!]!
+  modelNames(first: Int, last: Int, before: ModelNameWhereUniqueInput, after: ModelNameWhereUniqueInput, skip: Int): [ModelName!]!
 }
 
 input StringFilter {
@@ -99,12 +99,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   alias?: Alias
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
-
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
 
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
@@ -324,6 +318,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {

--- a/tests/schema/__snapshots__/naming.test.ts.snap
+++ b/tests/schema/__snapshots__/naming.test.ts.snap
@@ -56,7 +56,7 @@ type Mutation {
 
 type Query {
   modelName(where: ModelNameWhereUniqueInput!): ModelName
-  modelNames(first: Int, last: Int, before: ModelNameWhereUniqueInput, after: ModelNameWhereUniqueInput, skip: Int): [ModelName!]!
+  modelNames(first: Int, last: Int, before: ModelNameWhereUniqueInput, after: ModelNameWhereUniqueInput): [ModelName!]!
 }
 
 input StringFilter {
@@ -323,7 +323,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }

--- a/tests/schema/__snapshots__/outputs.test.ts.snap
+++ b/tests/schema/__snapshots__/outputs.test.ts.snap
@@ -26,7 +26,7 @@ input IntFilter {
 }
 
 type Query {
-  users(where: UserWhereInput, cursor: UserWhereUniqueInput, take: Int, skip: Int): [User!]!
+  users(where: UserWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput, skip: Int): [User!]!
 }
 
 type User {
@@ -71,12 +71,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   alias?: Alias
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
-
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
 
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
@@ -296,6 +290,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {

--- a/tests/schema/__snapshots__/outputs.test.ts.snap
+++ b/tests/schema/__snapshots__/outputs.test.ts.snap
@@ -26,7 +26,7 @@ input IntFilter {
 }
 
 type Query {
-  users(where: UserWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput, skip: Int): [User!]!
+  users(where: UserWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput): [User!]!
 }
 
 type User {
@@ -295,7 +295,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }

--- a/tests/schema/__snapshots__/scalars.test.ts.snap
+++ b/tests/schema/__snapshots__/scalars.test.ts.snap
@@ -266,7 +266,6 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
 type Pagination = {
   first?: boolean
   last?: boolean
-  skip?: boolean
   before?: boolean
   after?: boolean
 }

--- a/tests/schema/__snapshots__/scalars.test.ts.snap
+++ b/tests/schema/__snapshots__/scalars.test.ts.snap
@@ -43,12 +43,6 @@ type NexusPrismaScalarOpts<TypeName extends string, MethodName extends string, A
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
 
-type Pagination = {
-  skip?: boolean
-  take?: boolean
-  cursor?: boolean
-}
-
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 
 /**
@@ -267,6 +261,15 @@ type GetNexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud
           ? GetNexusPrismaMethod<TypeName>
           : never
       : never
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  skip?: boolean
+  before?: boolean
+  after?: boolean
+}
 
 // Generated
 interface ModelTypes {


### PR DESCRIPTION
This PR brings the concept of "Pagination Strategies", allowing us to customize how pagination is handled.

It also brings back the old pagination model so that the new Prisma Client pagination doesn't break existing users.

### EDIT

This PR is partially breaking the old pagination.

- `skip` has been removed to move towards a cursor-based pagination style only. It'll be possible to bring it back in case lots of people were using the offset-based pagination.

- Also, a few combinations aren't possible to handle anymore such as:
  - `after` + `last`
  - `before` + `first`


## TODO
- [x] Validate error handling for the pagination args
- [x] Validate mapping between pagination args to PC args