### PR TITLE
feat: allow computedInputs to be async

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -320,7 +320,7 @@ export class SchemaBuilder {
             })
             const schemaArgsIndex = indexBy(mappedField.field.args, 'name')
 
-            const originalResolve: GraphQLFieldResolver<any, any, any> = (_root, args, ctx, info) => {
+            const originalResolve: GraphQLFieldResolver<any, any, any> = async (_root, args, ctx, info) => {
               const prismaClient = this.getPrismaClient(ctx)
               args = transformNullsToUndefined(args, schemaArgsIndex, this.dmmf)
               if (
@@ -328,7 +328,7 @@ export class SchemaBuilder {
                 (!isEmptyObject(publisherConfig.locallyComputedInputs) ||
                   !isEmptyObject(this.globallyComputedInputs))
               ) {
-                args = addComputedInputs({
+                args = await addComputedInputs({
                   inputType,
                   dmmf: this.dmmf,
                   params: {


### PR DESCRIPTION
i am testing it out right now, seems to work!

maybe there should be an end-to-end test for that, but i could not run them locally, so i skipped that for the moment

solves https://github.com/graphql-nexus/nexus-plugin-prisma/issues/665

solves https://github.com/graphql-nexus/nexus/issues/1353