### PR TITLE
feat(deps): upgrade prisma to 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "test:db:setup": "docker-compose down && rm -rf .mysql-data && rm -rf .postgres-data && docker-compose up -d"
   },
   "dependencies": {
-    "@prisma/cli": "^2.6.0-dev.38",
-    "@prisma/client": "^2.6.0-dev.38",
-    "@prisma/sdk": "^2.6.0-dev.38",
+    "@prisma/cli": "2.6.0",
+    "@prisma/client": "2.6.0",
+    "@prisma/sdk": "2.6.0",
     "camelcase": "^6.0.0",
     "chalk": "^4.0.0",
     "common-tags": "^1.8.0",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@nexus/schema": "^0.15.0",
     "@prisma-labs/prettier-config": "0.1.0",
-    "@prisma/fetch-engine": "^2.6.0-dev.38",
-    "@prisma/get-platform": "^2.6.0-dev.38",
-    "@prisma/migrate": "^2.6.0-dev.38",
+    "@prisma/fetch-engine": "2.6.0",
+    "@prisma/get-platform": "2.6.0",
+    "@prisma/migrate": "2.6.0",
     "@types/common-tags": "1.8.0",
     "@types/jest": "25.2.3",
     "@types/lodash": "4.14.157",

--- a/tests/schema/__app/generated/nexus-plugin-prisma-typegen.d.ts
+++ b/tests/schema/__app/generated/nexus-plugin-prisma-typegen.d.ts
@@ -36,8 +36,8 @@ interface NexusPrismaInputs {
       ordering: 'id' | 'country' | 'city'
     }
     posts: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'authors' | 'rating' | 'status'
-      ordering: 'id' | 'rating' | 'status'
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'authors' | 'rating' | 'likes' | 'status'
+      ordering: 'id' | 'rating' | 'likes' | 'status'
     }
   },
   Bubble: {
@@ -48,8 +48,8 @@ interface NexusPrismaInputs {
   }
   User: {
     posts: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'authors' | 'rating' | 'status'
-      ordering: 'id' | 'rating' | 'status'
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'authors' | 'rating' | 'likes' | 'status'
+      ordering: 'id' | 'rating' | 'likes' | 'status'
     }
   }
   Location: {
@@ -130,6 +130,7 @@ interface NexusPrismaOutputs {
     id: 'Int'
     authors: 'User'
     rating: 'Float'
+    likes: 'Int'
     status: 'PostStatus'
   }
 }

--- a/tests/schema/__app/generated/nexus-typegen.d.ts
+++ b/tests/schema/__app/generated/nexus-typegen.d.ts
@@ -79,6 +79,13 @@ export interface NexusGenInputs {
     not?: NexusGenInputs['NestedFloatFilter'] | null; // NestedFloatFilter
     notIn?: number[] | null; // [Float!]
   }
+  IntFieldUpdateOperationsInput: { // input type
+    decrement?: number | null; // Int
+    divide?: number | null; // Int
+    increment?: number | null; // Int
+    multiply?: number | null; // Int
+    set?: number | null; // Int
+  }
   IntFilter: { // input type
     equals?: number | null; // Int
     gt?: number | null; // Int
@@ -171,6 +178,7 @@ export interface NexusGenInputs {
   }
   PostCreateInput: { // input type
     authors?: NexusGenInputs['UserCreateManyWithoutPostsInput'] | null; // UserCreateManyWithoutPostsInput
+    likes: number; // Int!
     rating: number; // Float!
     status: NexusGenEnums['PostStatus']; // PostStatus!
   }
@@ -181,10 +189,12 @@ export interface NexusGenInputs {
   }
   PostOrderByInput: { // input type
     id?: NexusGenEnums['SortOrder'] | null; // SortOrder
+    likes?: NexusGenEnums['SortOrder'] | null; // SortOrder
     rating?: NexusGenEnums['SortOrder'] | null; // SortOrder
     status?: NexusGenEnums['SortOrder'] | null; // SortOrder
   }
   PostUpdateManyMutationInput: { // input type
+    likes?: NexusGenInputs['IntFieldUpdateOperationsInput'] | null; // IntFieldUpdateOperationsInput
     rating?: NexusGenInputs['FloatFieldUpdateOperationsInput'] | null; // FloatFieldUpdateOperationsInput
     status?: NexusGenEnums['PostStatus'] | null; // PostStatus
   }
@@ -192,6 +202,7 @@ export interface NexusGenInputs {
     AND?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
     authors?: NexusGenInputs['UserListRelationFilter'] | null; // UserListRelationFilter
     id?: NexusGenInputs['IntFilter'] | null; // IntFilter
+    likes?: NexusGenInputs['IntFilter'] | null; // IntFilter
     NOT?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
     OR?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
     rating?: NexusGenInputs['FloatFilter'] | null; // FloatFilter
@@ -310,6 +321,7 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   DateTimeFilter: NexusGenInputs['DateTimeFilter'];
   FloatFieldUpdateOperationsInput: NexusGenInputs['FloatFieldUpdateOperationsInput'];
   FloatFilter: NexusGenInputs['FloatFilter'];
+  IntFieldUpdateOperationsInput: NexusGenInputs['IntFieldUpdateOperationsInput'];
   IntFilter: NexusGenInputs['IntFilter'];
   LocationCreateOneWithoutUserInput: NexusGenInputs['LocationCreateOneWithoutUserInput'];
   LocationCreateWithoutUserInput: NexusGenInputs['LocationCreateWithoutUserInput'];
@@ -426,7 +438,7 @@ export interface NexusGenInheritedFields {}
 
 export type NexusGenObjectNames = "BatchPayload" | "Bubble" | "Location" | "Mutation" | "Post" | "Query" | "User";
 
-export type NexusGenInputNames = "BoolFilter" | "BubbleCreateOneWithoutMembersInput" | "BubbleCreateWithoutMembersInput" | "BubbleMembersOrderByInput" | "BubbleMembersWhereInput" | "BubbleWhereInput" | "BubbleWhereUniqueInput" | "DateTimeFilter" | "FloatFieldUpdateOperationsInput" | "FloatFilter" | "IntFilter" | "LocationCreateOneWithoutUserInput" | "LocationCreateWithoutUserInput" | "LocationWhereInput" | "LocationWhereUniqueInput" | "NestedBoolFilter" | "NestedDateTimeFilter" | "NestedFloatFilter" | "NestedIntFilter" | "NestedStringFilter" | "NestedStringNullableFilter" | "PostCreateInput" | "PostListRelationFilter" | "PostOrderByInput" | "PostUpdateManyMutationInput" | "PostWhereInput" | "PostWhereUniqueInput" | "StringFilter" | "StringNullableFilter" | "UserCreateManyWithoutPostsInput" | "UserCreateWithoutPostsInput" | "UserListRelationFilter" | "UserWhereInput" | "UserWhereUniqueInput";
+export type NexusGenInputNames = "BoolFilter" | "BubbleCreateOneWithoutMembersInput" | "BubbleCreateWithoutMembersInput" | "BubbleMembersOrderByInput" | "BubbleMembersWhereInput" | "BubbleWhereInput" | "BubbleWhereUniqueInput" | "DateTimeFilter" | "FloatFieldUpdateOperationsInput" | "FloatFilter" | "IntFieldUpdateOperationsInput" | "IntFilter" | "LocationCreateOneWithoutUserInput" | "LocationCreateWithoutUserInput" | "LocationWhereInput" | "LocationWhereUniqueInput" | "NestedBoolFilter" | "NestedDateTimeFilter" | "NestedFloatFilter" | "NestedIntFilter" | "NestedStringFilter" | "NestedStringNullableFilter" | "PostCreateInput" | "PostListRelationFilter" | "PostOrderByInput" | "PostUpdateManyMutationInput" | "PostWhereInput" | "PostWhereUniqueInput" | "StringFilter" | "StringNullableFilter" | "UserCreateManyWithoutPostsInput" | "UserCreateWithoutPostsInput" | "UserListRelationFilter" | "UserWhereInput" | "UserWhereUniqueInput";
 
 export type NexusGenEnumNames = "PostStatus" | "SortOrder";
 

--- a/tests/schema/__app/generated/nexus-typegen.d.ts
+++ b/tests/schema/__app/generated/nexus-typegen.d.ts
@@ -63,6 +63,10 @@ export interface NexusGenInputs {
     notIn?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
   }
   FloatFieldUpdateOperationsInput: { // input type
+    decrement?: number | null; // Float
+    divide?: number | null; // Float
+    increment?: number | null; // Float
+    multiply?: number | null; // Float
     set?: number | null; // Float
   }
   FloatFilter: { // input type

--- a/tests/schema/__app/generated/nexus-typegen.d.ts
+++ b/tests/schema/__app/generated/nexus-typegen.d.ts
@@ -62,6 +62,9 @@ export interface NexusGenInputs {
     not?: NexusGenInputs['NestedDateTimeFilter'] | null; // NestedDateTimeFilter
     notIn?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
   }
+  FloatFieldUpdateOperationsInput: { // input type
+    set?: number | null; // Float
+  }
   FloatFilter: { // input type
     equals?: number | null; // Float
     gt?: number | null; // Float
@@ -178,7 +181,7 @@ export interface NexusGenInputs {
     status?: NexusGenEnums['SortOrder'] | null; // SortOrder
   }
   PostUpdateManyMutationInput: { // input type
-    rating?: number | null; // Float
+    rating?: NexusGenInputs['FloatFieldUpdateOperationsInput'] | null; // FloatFieldUpdateOperationsInput
     status?: NexusGenEnums['PostStatus'] | null; // PostStatus
   }
   PostWhereInput: { // input type
@@ -301,6 +304,7 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   BubbleWhereInput: NexusGenInputs['BubbleWhereInput'];
   BubbleWhereUniqueInput: NexusGenInputs['BubbleWhereUniqueInput'];
   DateTimeFilter: NexusGenInputs['DateTimeFilter'];
+  FloatFieldUpdateOperationsInput: NexusGenInputs['FloatFieldUpdateOperationsInput'];
   FloatFilter: NexusGenInputs['FloatFilter'];
   IntFilter: NexusGenInputs['IntFilter'];
   LocationCreateOneWithoutUserInput: NexusGenInputs['LocationCreateOneWithoutUserInput'];
@@ -418,7 +422,7 @@ export interface NexusGenInheritedFields {}
 
 export type NexusGenObjectNames = "BatchPayload" | "Bubble" | "Location" | "Mutation" | "Post" | "Query" | "User";
 
-export type NexusGenInputNames = "BoolFilter" | "BubbleCreateOneWithoutMembersInput" | "BubbleCreateWithoutMembersInput" | "BubbleMembersOrderByInput" | "BubbleMembersWhereInput" | "BubbleWhereInput" | "BubbleWhereUniqueInput" | "DateTimeFilter" | "FloatFilter" | "IntFilter" | "LocationCreateOneWithoutUserInput" | "LocationCreateWithoutUserInput" | "LocationWhereInput" | "LocationWhereUniqueInput" | "NestedBoolFilter" | "NestedDateTimeFilter" | "NestedFloatFilter" | "NestedIntFilter" | "NestedStringFilter" | "NestedStringNullableFilter" | "PostCreateInput" | "PostListRelationFilter" | "PostOrderByInput" | "PostUpdateManyMutationInput" | "PostWhereInput" | "PostWhereUniqueInput" | "StringFilter" | "StringNullableFilter" | "UserCreateManyWithoutPostsInput" | "UserCreateWithoutPostsInput" | "UserListRelationFilter" | "UserWhereInput" | "UserWhereUniqueInput";
+export type NexusGenInputNames = "BoolFilter" | "BubbleCreateOneWithoutMembersInput" | "BubbleCreateWithoutMembersInput" | "BubbleMembersOrderByInput" | "BubbleMembersWhereInput" | "BubbleWhereInput" | "BubbleWhereUniqueInput" | "DateTimeFilter" | "FloatFieldUpdateOperationsInput" | "FloatFilter" | "IntFilter" | "LocationCreateOneWithoutUserInput" | "LocationCreateWithoutUserInput" | "LocationWhereInput" | "LocationWhereUniqueInput" | "NestedBoolFilter" | "NestedDateTimeFilter" | "NestedFloatFilter" | "NestedIntFilter" | "NestedStringFilter" | "NestedStringNullableFilter" | "PostCreateInput" | "PostListRelationFilter" | "PostOrderByInput" | "PostUpdateManyMutationInput" | "PostWhereInput" | "PostWhereUniqueInput" | "StringFilter" | "StringNullableFilter" | "UserCreateManyWithoutPostsInput" | "UserCreateWithoutPostsInput" | "UserListRelationFilter" | "UserWhereInput" | "UserWhereUniqueInput";
 
 export type NexusGenEnumNames = "PostStatus" | "SortOrder";
 

--- a/tests/schema/__app/generated/schema.graphql
+++ b/tests/schema/__app/generated/schema.graphql
@@ -65,6 +65,10 @@ input DateTimeFilter {
   notIn: [DateTime!]
 }
 
+input FloatFieldUpdateOperationsInput {
+  set: Float
+}
+
 input FloatFilter {
   equals: Float
   gt: Float
@@ -218,7 +222,7 @@ enum PostStatus {
 }
 
 input PostUpdateManyMutationInput {
-  rating: Float
+  rating: FloatFieldUpdateOperationsInput
   status: PostStatus
 }
 

--- a/tests/schema/__app/generated/schema.graphql
+++ b/tests/schema/__app/generated/schema.graphql
@@ -66,6 +66,10 @@ input DateTimeFilter {
 }
 
 input FloatFieldUpdateOperationsInput {
+  decrement: Float
+  divide: Float
+  increment: Float
+  multiply: Float
   set: Float
 }
 

--- a/tests/schema/__app/generated/schema.graphql
+++ b/tests/schema/__app/generated/schema.graphql
@@ -84,6 +84,14 @@ input FloatFilter {
   notIn: [Float!]
 }
 
+input IntFieldUpdateOperationsInput {
+  decrement: Int
+  divide: Int
+  increment: Int
+  multiply: Int
+  set: Int
+}
+
 input IntFilter {
   equals: Int
   gt: Int
@@ -204,6 +212,7 @@ type Post {
 
 input PostCreateInput {
   authors: UserCreateManyWithoutPostsInput
+  likes: Int!
   rating: Float!
   status: PostStatus!
 }
@@ -216,6 +225,7 @@ input PostListRelationFilter {
 
 input PostOrderByInput {
   id: SortOrder
+  likes: SortOrder
   rating: SortOrder
   status: SortOrder
 }
@@ -226,6 +236,7 @@ enum PostStatus {
 }
 
 input PostUpdateManyMutationInput {
+  likes: IntFieldUpdateOperationsInput
   rating: FloatFieldUpdateOperationsInput
   status: PostStatus
 }
@@ -234,6 +245,7 @@ input PostWhereInput {
   AND: [PostWhereInput!]
   authors: UserListRelationFilter
   id: IntFilter
+  likes: IntFilter
   NOT: [PostWhereInput!]
   OR: [PostWhereInput!]
   rating: FloatFilter

--- a/tests/schema/__app/schema.prisma
+++ b/tests/schema/__app/schema.prisma
@@ -34,6 +34,7 @@ model Post {
   id      Int        @id @default(autoincrement())
   authors User[]
   rating  Float
+  likes   Int
   status  PostStatus
   // likers  User[] @relation(references: likers)
 }

--- a/tests/schema/__app/schema.prisma
+++ b/tests/schema/__app/schema.prisma
@@ -1,6 +1,7 @@
 generator prisma_client {
-  provider = "prisma-client-js"
-  output   = "../../../node_modules/@prisma/client"
+  provider        = "prisma-client-js"
+  output          = "../../../node_modules/@prisma/client"
+  previewFeatures = ["atomicNumberOperations"]
 }
 
 model Bubble {
@@ -11,18 +12,22 @@ model Bubble {
 }
 
 model User {
-  id        String @id @default(cuid())
-  posts     Post[]
-  firstName String
-  lastName  String
-  location  Location
+  id         String   @id @default(cuid())
+  posts      Post[]
+  firstName  String
+  lastName   String
+  location   Location @relation(fields: [locationId], references: [id])
   // likes     Post[]
+  Bubble     Bubble?  @relation(fields: [bubbleId], references: [id])
+  bubbleId   String?
+  locationId Int
 }
 
 model Location {
-  id        Int @id @default(autoincrement())
-  country   String
-  city      String
+  id      Int    @id @default(autoincrement())
+  country String
+  city    String
+  User    User[]
 }
 
 model Post {

--- a/tests/schema/__snapshots__/app.test.ts.snap
+++ b/tests/schema/__snapshots__/app.test.ts.snap
@@ -89,6 +89,14 @@ input FloatFilter {
   notIn: [Float!]
 }
 
+input IntFieldUpdateOperationsInput {
+  decrement: Int
+  divide: Int
+  increment: Int
+  multiply: Int
+  set: Int
+}
+
 input IntFilter {
   equals: Int
   gt: Int
@@ -209,6 +217,7 @@ type Post {
 
 input PostCreateInput {
   authors: UserCreateManyWithoutPostsInput
+  likes: Int!
   rating: Float!
   status: PostStatus!
 }
@@ -221,6 +230,7 @@ input PostListRelationFilter {
 
 input PostOrderByInput {
   id: SortOrder
+  likes: SortOrder
   rating: SortOrder
   status: SortOrder
 }
@@ -231,6 +241,7 @@ enum PostStatus {
 }
 
 input PostUpdateManyMutationInput {
+  likes: IntFieldUpdateOperationsInput
   rating: FloatFieldUpdateOperationsInput
   status: PostStatus
 }
@@ -239,6 +250,7 @@ input PostWhereInput {
   AND: [PostWhereInput!]
   authors: UserListRelationFilter
   id: IntFilter
+  likes: IntFilter
   NOT: [PostWhereInput!]
   OR: [PostWhereInput!]
   rating: FloatFilter
@@ -415,6 +427,13 @@ export interface NexusGenInputs {
     not?: NexusGenInputs['NestedFloatFilter'] | null; // NestedFloatFilter
     notIn?: number[] | null; // [Float!]
   }
+  IntFieldUpdateOperationsInput: { // input type
+    decrement?: number | null; // Int
+    divide?: number | null; // Int
+    increment?: number | null; // Int
+    multiply?: number | null; // Int
+    set?: number | null; // Int
+  }
   IntFilter: { // input type
     equals?: number | null; // Int
     gt?: number | null; // Int
@@ -507,6 +526,7 @@ export interface NexusGenInputs {
   }
   PostCreateInput: { // input type
     authors?: NexusGenInputs['UserCreateManyWithoutPostsInput'] | null; // UserCreateManyWithoutPostsInput
+    likes: number; // Int!
     rating: number; // Float!
     status: NexusGenEnums['PostStatus']; // PostStatus!
   }
@@ -517,10 +537,12 @@ export interface NexusGenInputs {
   }
   PostOrderByInput: { // input type
     id?: NexusGenEnums['SortOrder'] | null; // SortOrder
+    likes?: NexusGenEnums['SortOrder'] | null; // SortOrder
     rating?: NexusGenEnums['SortOrder'] | null; // SortOrder
     status?: NexusGenEnums['SortOrder'] | null; // SortOrder
   }
   PostUpdateManyMutationInput: { // input type
+    likes?: NexusGenInputs['IntFieldUpdateOperationsInput'] | null; // IntFieldUpdateOperationsInput
     rating?: NexusGenInputs['FloatFieldUpdateOperationsInput'] | null; // FloatFieldUpdateOperationsInput
     status?: NexusGenEnums['PostStatus'] | null; // PostStatus
   }
@@ -528,6 +550,7 @@ export interface NexusGenInputs {
     AND?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
     authors?: NexusGenInputs['UserListRelationFilter'] | null; // UserListRelationFilter
     id?: NexusGenInputs['IntFilter'] | null; // IntFilter
+    likes?: NexusGenInputs['IntFilter'] | null; // IntFilter
     NOT?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
     OR?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
     rating?: NexusGenInputs['FloatFilter'] | null; // FloatFilter
@@ -646,6 +669,7 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   DateTimeFilter: NexusGenInputs['DateTimeFilter'];
   FloatFieldUpdateOperationsInput: NexusGenInputs['FloatFieldUpdateOperationsInput'];
   FloatFilter: NexusGenInputs['FloatFilter'];
+  IntFieldUpdateOperationsInput: NexusGenInputs['IntFieldUpdateOperationsInput'];
   IntFilter: NexusGenInputs['IntFilter'];
   LocationCreateOneWithoutUserInput: NexusGenInputs['LocationCreateOneWithoutUserInput'];
   LocationCreateWithoutUserInput: NexusGenInputs['LocationCreateWithoutUserInput'];
@@ -762,7 +786,7 @@ export interface NexusGenInheritedFields {}
 
 export type NexusGenObjectNames = \\"BatchPayload\\" | \\"Bubble\\" | \\"Location\\" | \\"Mutation\\" | \\"Post\\" | \\"Query\\" | \\"User\\";
 
-export type NexusGenInputNames = \\"BoolFilter\\" | \\"BubbleCreateOneWithoutMembersInput\\" | \\"BubbleCreateWithoutMembersInput\\" | \\"BubbleMembersOrderByInput\\" | \\"BubbleMembersWhereInput\\" | \\"BubbleWhereInput\\" | \\"BubbleWhereUniqueInput\\" | \\"DateTimeFilter\\" | \\"FloatFieldUpdateOperationsInput\\" | \\"FloatFilter\\" | \\"IntFilter\\" | \\"LocationCreateOneWithoutUserInput\\" | \\"LocationCreateWithoutUserInput\\" | \\"LocationWhereInput\\" | \\"LocationWhereUniqueInput\\" | \\"NestedBoolFilter\\" | \\"NestedDateTimeFilter\\" | \\"NestedFloatFilter\\" | \\"NestedIntFilter\\" | \\"NestedStringFilter\\" | \\"NestedStringNullableFilter\\" | \\"PostCreateInput\\" | \\"PostListRelationFilter\\" | \\"PostOrderByInput\\" | \\"PostUpdateManyMutationInput\\" | \\"PostWhereInput\\" | \\"PostWhereUniqueInput\\" | \\"StringFilter\\" | \\"StringNullableFilter\\" | \\"UserCreateManyWithoutPostsInput\\" | \\"UserCreateWithoutPostsInput\\" | \\"UserListRelationFilter\\" | \\"UserWhereInput\\" | \\"UserWhereUniqueInput\\";
+export type NexusGenInputNames = \\"BoolFilter\\" | \\"BubbleCreateOneWithoutMembersInput\\" | \\"BubbleCreateWithoutMembersInput\\" | \\"BubbleMembersOrderByInput\\" | \\"BubbleMembersWhereInput\\" | \\"BubbleWhereInput\\" | \\"BubbleWhereUniqueInput\\" | \\"DateTimeFilter\\" | \\"FloatFieldUpdateOperationsInput\\" | \\"FloatFilter\\" | \\"IntFieldUpdateOperationsInput\\" | \\"IntFilter\\" | \\"LocationCreateOneWithoutUserInput\\" | \\"LocationCreateWithoutUserInput\\" | \\"LocationWhereInput\\" | \\"LocationWhereUniqueInput\\" | \\"NestedBoolFilter\\" | \\"NestedDateTimeFilter\\" | \\"NestedFloatFilter\\" | \\"NestedIntFilter\\" | \\"NestedStringFilter\\" | \\"NestedStringNullableFilter\\" | \\"PostCreateInput\\" | \\"PostListRelationFilter\\" | \\"PostOrderByInput\\" | \\"PostUpdateManyMutationInput\\" | \\"PostWhereInput\\" | \\"PostWhereUniqueInput\\" | \\"StringFilter\\" | \\"StringNullableFilter\\" | \\"UserCreateManyWithoutPostsInput\\" | \\"UserCreateWithoutPostsInput\\" | \\"UserListRelationFilter\\" | \\"UserWhereInput\\" | \\"UserWhereUniqueInput\\";
 
 export type NexusGenEnumNames = \\"PostStatus\\" | \\"SortOrder\\";
 
@@ -843,8 +867,8 @@ interface NexusPrismaInputs {
       ordering: 'id' | 'country' | 'city'
     }
     posts: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'authors' | 'rating' | 'status'
-      ordering: 'id' | 'rating' | 'status'
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'authors' | 'rating' | 'likes' | 'status'
+      ordering: 'id' | 'rating' | 'likes' | 'status'
     }
   },
   Bubble: {
@@ -855,8 +879,8 @@ interface NexusPrismaInputs {
   }
   User: {
     posts: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'authors' | 'rating' | 'status'
-      ordering: 'id' | 'rating' | 'status'
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'authors' | 'rating' | 'likes' | 'status'
+      ordering: 'id' | 'rating' | 'likes' | 'status'
     }
   }
   Location: {
@@ -937,6 +961,7 @@ interface NexusPrismaOutputs {
     id: 'Int'
     authors: 'User'
     rating: 'Float'
+    likes: 'Int'
     status: 'PostStatus'
   }
 }
@@ -1333,6 +1358,19 @@ Object {
             "isRequired": true,
             "isUnique": false,
             "isUpdatedAt": false,
+            "kind": "scalar",
+            "name": "likes",
+            "type": "Int",
+          },
+          Object {
+            "hasDefaultValue": false,
+            "isGenerated": false,
+            "isId": false,
+            "isList": false,
+            "isReadOnly": false,
+            "isRequired": true,
+            "isUnique": false,
+            "isUpdatedAt": false,
             "kind": "enum",
             "name": "status",
             "type": "PostStatus",
@@ -1434,6 +1472,7 @@ Object {
         "values": Array [
           "id",
           "rating",
+          "likes",
           "status",
         ],
       },
@@ -2162,6 +2201,25 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "IntFilter",
+              },
+            ],
+            "name": "likes",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
                 "kind": "enum",
                 "type": "PostStatus",
               },
@@ -2205,6 +2263,18 @@ Object {
               },
             ],
             "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "likes",
           },
           Object {
             "inputType": Array [
@@ -2842,6 +2912,18 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": true,
+                "kind": "scalar",
+                "type": "Int",
+              },
+            ],
+            "name": "likes",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
                 "kind": "enum",
                 "type": "PostStatus",
               },
@@ -2884,6 +2966,25 @@ Object {
               },
             ],
             "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "IntFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "likes",
           },
           Object {
             "inputType": Array [
@@ -2941,6 +3042,25 @@ Object {
               },
             ],
             "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "IntFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "likes",
           },
           Object {
             "inputType": Array [
@@ -4611,6 +4731,73 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+            ],
+            "name": "set",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+            ],
+            "name": "increment",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+            ],
+            "name": "decrement",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+            ],
+            "name": "multiply",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+            ],
+            "name": "divide",
+          },
+        ],
+        "isOneOf": true,
+        "isUpdateOperationType": true,
+        "name": "IntFieldUpdateOperationsInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
                 "kind": "enum",
                 "type": "PostStatus",
               },
@@ -5735,6 +5922,18 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": true,
+                "kind": "scalar",
+                "type": "Int",
+              },
+            ],
+            "name": "likes",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
                 "kind": "enum",
                 "type": "PostStatus",
               },
@@ -5952,6 +6151,25 @@ Object {
               },
             ],
             "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "IntFilter",
+              },
+            ],
+            "name": "likes",
           },
           Object {
             "inputType": Array [
@@ -6556,6 +6774,18 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
+                "type": "IntFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "likes",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
                 "type": "EnumPostStatusFieldUpdateOperationsInput",
               },
             ],
@@ -6578,6 +6808,18 @@ Object {
               },
             ],
             "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "IntFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "likes",
           },
           Object {
             "inputType": Array [
@@ -9003,6 +9245,17 @@ Object {
           },
           Object {
             "args": Array [],
+            "name": "likes",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+          Object {
+            "args": Array [],
             "name": "status",
             "outputType": Object {
               "isList": false,
@@ -9243,6 +9496,17 @@ Object {
               "type": "Float",
             },
           },
+          Object {
+            "args": Array [],
+            "name": "likes",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Float",
+            },
+          },
         ],
         "name": "PostAvgAggregateOutputType",
       },
@@ -9268,6 +9532,17 @@ Object {
               "isRequired": true,
               "kind": "scalar",
               "type": "Float",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "likes",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
             },
           },
         ],
@@ -9297,6 +9572,17 @@ Object {
               "type": "Float",
             },
           },
+          Object {
+            "args": Array [],
+            "name": "likes",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
         ],
         "name": "PostMinAggregateOutputType",
       },
@@ -9322,6 +9608,17 @@ Object {
               "isRequired": true,
               "kind": "scalar",
               "type": "Float",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "likes",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
             },
           },
         ],

--- a/tests/schema/__snapshots__/app.test.ts.snap
+++ b/tests/schema/__snapshots__/app.test.ts.snap
@@ -71,6 +71,10 @@ input DateTimeFilter {
 }
 
 input FloatFieldUpdateOperationsInput {
+  decrement: Float
+  divide: Float
+  increment: Float
+  multiply: Float
   set: Float
 }
 
@@ -395,6 +399,10 @@ export interface NexusGenInputs {
     notIn?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
   }
   FloatFieldUpdateOperationsInput: { // input type
+    decrement?: number | null; // Float
+    divide?: number | null; // Float
+    increment?: number | null; // Float
+    multiply?: number | null; // Float
     set?: number | null; // Float
   }
   FloatFilter: { // input type
@@ -1140,7 +1148,7 @@ Object {
           },
           Object {
             "hasDefaultValue": false,
-            "isGenerated": true,
+            "isGenerated": false,
             "isId": false,
             "isList": false,
             "isReadOnly": false,
@@ -1241,7 +1249,7 @@ Object {
           },
           Object {
             "hasDefaultValue": false,
-            "isGenerated": true,
+            "isGenerated": false,
             "isId": false,
             "isList": true,
             "isReadOnly": false,
@@ -4541,6 +4549,54 @@ Object {
               },
             ],
             "name": "set",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "increment",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "decrement",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "multiply",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "divide",
           },
         ],
         "isOneOf": true,

--- a/tests/schema/__snapshots__/app.test.ts.snap
+++ b/tests/schema/__snapshots__/app.test.ts.snap
@@ -70,6 +70,10 @@ input DateTimeFilter {
   notIn: [DateTime!]
 }
 
+input FloatFieldUpdateOperationsInput {
+  set: Float
+}
+
 input FloatFilter {
   equals: Float
   gt: Float
@@ -223,7 +227,7 @@ enum PostStatus {
 }
 
 input PostUpdateManyMutationInput {
-  rating: Float
+  rating: FloatFieldUpdateOperationsInput
   status: PostStatus
 }
 
@@ -390,6 +394,9 @@ export interface NexusGenInputs {
     not?: NexusGenInputs['NestedDateTimeFilter'] | null; // NestedDateTimeFilter
     notIn?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
   }
+  FloatFieldUpdateOperationsInput: { // input type
+    set?: number | null; // Float
+  }
   FloatFilter: { // input type
     equals?: number | null; // Float
     gt?: number | null; // Float
@@ -506,7 +513,7 @@ export interface NexusGenInputs {
     status?: NexusGenEnums['SortOrder'] | null; // SortOrder
   }
   PostUpdateManyMutationInput: { // input type
-    rating?: number | null; // Float
+    rating?: NexusGenInputs['FloatFieldUpdateOperationsInput'] | null; // FloatFieldUpdateOperationsInput
     status?: NexusGenEnums['PostStatus'] | null; // PostStatus
   }
   PostWhereInput: { // input type
@@ -629,6 +636,7 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   BubbleWhereInput: NexusGenInputs['BubbleWhereInput'];
   BubbleWhereUniqueInput: NexusGenInputs['BubbleWhereUniqueInput'];
   DateTimeFilter: NexusGenInputs['DateTimeFilter'];
+  FloatFieldUpdateOperationsInput: NexusGenInputs['FloatFieldUpdateOperationsInput'];
   FloatFilter: NexusGenInputs['FloatFilter'];
   IntFilter: NexusGenInputs['IntFilter'];
   LocationCreateOneWithoutUserInput: NexusGenInputs['LocationCreateOneWithoutUserInput'];
@@ -746,7 +754,7 @@ export interface NexusGenInheritedFields {}
 
 export type NexusGenObjectNames = \\"BatchPayload\\" | \\"Bubble\\" | \\"Location\\" | \\"Mutation\\" | \\"Post\\" | \\"Query\\" | \\"User\\";
 
-export type NexusGenInputNames = \\"BoolFilter\\" | \\"BubbleCreateOneWithoutMembersInput\\" | \\"BubbleCreateWithoutMembersInput\\" | \\"BubbleMembersOrderByInput\\" | \\"BubbleMembersWhereInput\\" | \\"BubbleWhereInput\\" | \\"BubbleWhereUniqueInput\\" | \\"DateTimeFilter\\" | \\"FloatFilter\\" | \\"IntFilter\\" | \\"LocationCreateOneWithoutUserInput\\" | \\"LocationCreateWithoutUserInput\\" | \\"LocationWhereInput\\" | \\"LocationWhereUniqueInput\\" | \\"NestedBoolFilter\\" | \\"NestedDateTimeFilter\\" | \\"NestedFloatFilter\\" | \\"NestedIntFilter\\" | \\"NestedStringFilter\\" | \\"NestedStringNullableFilter\\" | \\"PostCreateInput\\" | \\"PostListRelationFilter\\" | \\"PostOrderByInput\\" | \\"PostUpdateManyMutationInput\\" | \\"PostWhereInput\\" | \\"PostWhereUniqueInput\\" | \\"StringFilter\\" | \\"StringNullableFilter\\" | \\"UserCreateManyWithoutPostsInput\\" | \\"UserCreateWithoutPostsInput\\" | \\"UserListRelationFilter\\" | \\"UserWhereInput\\" | \\"UserWhereUniqueInput\\";
+export type NexusGenInputNames = \\"BoolFilter\\" | \\"BubbleCreateOneWithoutMembersInput\\" | \\"BubbleCreateWithoutMembersInput\\" | \\"BubbleMembersOrderByInput\\" | \\"BubbleMembersWhereInput\\" | \\"BubbleWhereInput\\" | \\"BubbleWhereUniqueInput\\" | \\"DateTimeFilter\\" | \\"FloatFieldUpdateOperationsInput\\" | \\"FloatFilter\\" | \\"IntFilter\\" | \\"LocationCreateOneWithoutUserInput\\" | \\"LocationCreateWithoutUserInput\\" | \\"LocationWhereInput\\" | \\"LocationWhereUniqueInput\\" | \\"NestedBoolFilter\\" | \\"NestedDateTimeFilter\\" | \\"NestedFloatFilter\\" | \\"NestedIntFilter\\" | \\"NestedStringFilter\\" | \\"NestedStringNullableFilter\\" | \\"PostCreateInput\\" | \\"PostListRelationFilter\\" | \\"PostOrderByInput\\" | \\"PostUpdateManyMutationInput\\" | \\"PostWhereInput\\" | \\"PostWhereUniqueInput\\" | \\"StringFilter\\" | \\"StringNullableFilter\\" | \\"UserCreateManyWithoutPostsInput\\" | \\"UserCreateWithoutPostsInput\\" | \\"UserListRelationFilter\\" | \\"UserWhereInput\\" | \\"UserWhereUniqueInput\\";
 
 export type NexusGenEnumNames = \\"PostStatus\\" | \\"SortOrder\\";
 
@@ -1388,20 +1396,6 @@ Object {
   "schema": Object {
     "enums": Array [
       Object {
-        "name": "PostStatus",
-        "values": Array [
-          "DRAFT",
-          "PUBLISHED",
-        ],
-      },
-      Object {
-        "name": "SortOrder",
-        "values": Array [
-          "asc",
-          "desc",
-        ],
-      },
-      Object {
         "name": "BubbleDistinctFieldEnum",
         "values": Array [
           "id",
@@ -1420,6 +1414,14 @@ Object {
         ],
       },
       Object {
+        "name": "LocationDistinctFieldEnum",
+        "values": Array [
+          "id",
+          "country",
+          "city",
+        ],
+      },
+      Object {
         "name": "PostDistinctFieldEnum",
         "values": Array [
           "id",
@@ -1428,15 +1430,810 @@ Object {
         ],
       },
       Object {
-        "name": "LocationDistinctFieldEnum",
+        "name": "SortOrder",
         "values": Array [
-          "id",
-          "country",
-          "city",
+          "asc",
+          "desc",
+        ],
+      },
+      Object {
+        "name": "PostStatus",
+        "values": Array [
+          "DRAFT",
+          "PUBLISHED",
         ],
       },
     ],
     "inputTypes": Array [
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleWhereInput",
+              },
+            ],
+            "name": "AND",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleWhereInput",
+              },
+            ],
+            "name": "OR",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleWhereInput",
+              },
+            ],
+            "name": "NOT",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFilter",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "DateTimeFilter",
+              },
+            ],
+            "name": "createdAt",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserListRelationFilter",
+              },
+            ],
+            "name": "members",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Boolean",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BoolFilter",
+              },
+            ],
+            "name": "private",
+          },
+        ],
+        "isOneOf": false,
+        "isWhereType": true,
+        "name": "BubbleWhereInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "createdAt",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "private",
+          },
+        ],
+        "isOneOf": true,
+        "isOrderType": true,
+        "name": "BubbleOrderByInput",
+      },
+      Object {
+        "atLeastOne": true,
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "id",
+          },
+        ],
+        "isOneOf": true,
+        "name": "BubbleWhereUniqueInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereInput",
+              },
+            ],
+            "name": "AND",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereInput",
+              },
+            ],
+            "name": "OR",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereInput",
+              },
+            ],
+            "name": "NOT",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFilter",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostListRelationFilter",
+              },
+            ],
+            "name": "posts",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFilter",
+              },
+            ],
+            "name": "firstName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFilter",
+              },
+            ],
+            "name": "lastName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationWhereInput",
+              },
+            ],
+            "name": "location",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleWhereInput",
+              },
+            ],
+            "name": "Bubble",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringNullableFilter",
+              },
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "null",
+              },
+            ],
+            "name": "bubbleId",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "IntFilter",
+              },
+            ],
+            "name": "locationId",
+          },
+        ],
+        "isOneOf": false,
+        "isWhereType": true,
+        "name": "UserWhereInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "firstName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "lastName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "bubbleId",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "locationId",
+          },
+        ],
+        "isOneOf": true,
+        "isOrderType": true,
+        "name": "UserOrderByInput",
+      },
+      Object {
+        "atLeastOne": true,
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "id",
+          },
+        ],
+        "isOneOf": true,
+        "name": "UserWhereUniqueInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationWhereInput",
+              },
+            ],
+            "name": "AND",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationWhereInput",
+              },
+            ],
+            "name": "OR",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationWhereInput",
+              },
+            ],
+            "name": "NOT",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "IntFilter",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFilter",
+              },
+            ],
+            "name": "country",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFilter",
+              },
+            ],
+            "name": "city",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserListRelationFilter",
+              },
+            ],
+            "name": "User",
+          },
+        ],
+        "isOneOf": false,
+        "isWhereType": true,
+        "name": "LocationWhereInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "country",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "city",
+          },
+        ],
+        "isOneOf": true,
+        "isOrderType": true,
+        "name": "LocationOrderByInput",
+      },
+      Object {
+        "atLeastOne": true,
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+            ],
+            "name": "id",
+          },
+        ],
+        "isOneOf": true,
+        "name": "LocationWhereUniqueInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereInput",
+              },
+            ],
+            "name": "AND",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereInput",
+              },
+            ],
+            "name": "OR",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereInput",
+              },
+            ],
+            "name": "NOT",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "IntFilter",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserListRelationFilter",
+              },
+            ],
+            "name": "authors",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "FloatFilter",
+              },
+            ],
+            "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "PostStatus",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "EnumPostStatusFilter",
+              },
+            ],
+            "name": "status",
+          },
+        ],
+        "isOneOf": false,
+        "isWhereType": true,
+        "name": "PostWhereInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "SortOrder",
+              },
+            ],
+            "name": "status",
+          },
+        ],
+        "isOneOf": true,
+        "isOrderType": true,
+        "name": "PostOrderByInput",
+      },
+      Object {
+        "atLeastOne": true,
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+            ],
+            "name": "id",
+          },
+        ],
+        "isOneOf": true,
+        "name": "PostWhereUniqueInput",
+      },
       Object {
         "fields": Array [
           Object {
@@ -1449,31 +2246,7 @@ Object {
                 "type": "String",
               },
             ],
-            "name": "equals",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "in",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "notIn",
+            "name": "id",
           },
           Object {
             "inputType": Array [
@@ -1482,98 +2255,708 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "String",
+                "type": "DateTime",
               },
             ],
-            "name": "lt",
+            "name": "createdAt",
           },
           Object {
             "inputType": Array [
               Object {
                 "isList": false,
                 "isNullable": false,
-                "isRequired": false,
+                "isRequired": true,
                 "kind": "scalar",
-                "type": "String",
+                "type": "Boolean",
               },
             ],
-            "name": "lte",
+            "name": "private",
           },
           Object {
             "inputType": Array [
               Object {
                 "isList": false,
                 "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "gt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "gte",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "contains",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "startsWith",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "endsWith",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": true,
                 "isRequired": false,
                 "kind": "object",
-                "type": "NestedStringFilter",
+                "type": "UserCreateManyWithoutBubbleInput",
               },
             ],
-            "name": "not",
+            "name": "members",
           },
         ],
         "isOneOf": false,
-        "name": "NestedStringFilter",
+        "name": "BubbleCreateInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "DateTimeFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "createdAt",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Boolean",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BoolFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "private",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpdateManyWithoutBubbleInput",
+              },
+            ],
+            "name": "members",
+          },
+        ],
+        "isOneOf": false,
+        "isUpdateType": true,
+        "name": "BubbleUpdateInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "DateTimeFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "createdAt",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Boolean",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BoolFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "private",
+          },
+        ],
+        "isOneOf": false,
+        "isUpdateType": true,
+        "name": "BubbleUpdateManyMutationInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "firstName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "lastName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostCreateManyWithoutAuthorsInput",
+              },
+            ],
+            "name": "posts",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "LocationCreateOneWithoutUserInput",
+              },
+            ],
+            "name": "location",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleCreateOneWithoutMembersInput",
+              },
+            ],
+            "name": "Bubble",
+          },
+        ],
+        "isOneOf": false,
+        "name": "UserCreateInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "firstName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "lastName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostUpdateManyWithoutAuthorsInput",
+              },
+            ],
+            "name": "posts",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationUpdateOneRequiredWithoutUserInput",
+              },
+            ],
+            "name": "location",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleUpdateOneWithoutMembersInput",
+              },
+            ],
+            "name": "Bubble",
+          },
+        ],
+        "isOneOf": false,
+        "isUpdateType": true,
+        "name": "UserUpdateInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "firstName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "lastName",
+          },
+        ],
+        "isOneOf": false,
+        "isUpdateType": true,
+        "name": "UserUpdateManyMutationInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "country",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "city",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserCreateManyWithoutLocationInput",
+              },
+            ],
+            "name": "User",
+          },
+        ],
+        "isOneOf": false,
+        "name": "LocationCreateInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "country",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "city",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpdateManyWithoutLocationInput",
+              },
+            ],
+            "name": "User",
+          },
+        ],
+        "isOneOf": false,
+        "isUpdateType": true,
+        "name": "LocationUpdateInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "country",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "city",
+          },
+        ],
+        "isOneOf": false,
+        "isUpdateType": true,
+        "name": "LocationUpdateManyMutationInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "enum",
+                "type": "PostStatus",
+              },
+            ],
+            "name": "status",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserCreateManyWithoutPostsInput",
+              },
+            ],
+            "name": "authors",
+          },
+        ],
+        "isOneOf": false,
+        "name": "PostCreateInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "FloatFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "PostStatus",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "EnumPostStatusFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "status",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpdateManyWithoutPostsInput",
+              },
+            ],
+            "name": "authors",
+          },
+        ],
+        "isOneOf": false,
+        "isUpdateType": true,
+        "name": "PostUpdateInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "FloatFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "PostStatus",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "EnumPostStatusFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "status",
+          },
+        ],
+        "isOneOf": false,
+        "isUpdateType": true,
+        "name": "PostUpdateManyMutationInput",
       },
       Object {
         "fields": Array [
@@ -1810,108 +3193,6 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "NestedDateTimeFilter",
-              },
-            ],
-            "name": "not",
-          },
-        ],
-        "isOneOf": false,
-        "name": "NestedDateTimeFilter",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "equals",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "in",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "notIn",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "lt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "lte",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "gt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "gte",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
@@ -1939,8 +3220,189 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereInput",
+              },
+            ],
+            "name": "every",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereInput",
+              },
+            ],
+            "name": "some",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereInput",
+              },
+            ],
+            "name": "none",
+          },
+        ],
+        "isOneOf": false,
+        "name": "UserListRelationFilter",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
                 "kind": "scalar",
-                "type": "Int",
+                "type": "Boolean",
+              },
+            ],
+            "name": "equals",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Boolean",
+              },
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "NestedBoolFilter",
+              },
+            ],
+            "name": "not",
+          },
+        ],
+        "isOneOf": false,
+        "name": "BoolFilter",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereInput",
+              },
+            ],
+            "name": "every",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereInput",
+              },
+            ],
+            "name": "some",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereInput",
+              },
+            ],
+            "name": "none",
+          },
+        ],
+        "isOneOf": false,
+        "name": "PostListRelationFilter",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationWhereInput",
+              },
+            ],
+            "name": "is",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationWhereInput",
+              },
+            ],
+            "name": "isNot",
+          },
+        ],
+        "isOneOf": false,
+        "name": "LocationRelationFilter",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleWhereInput",
+              },
+            ],
+            "name": "is",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleWhereInput",
+              },
+            ],
+            "name": "isNot",
+          },
+        ],
+        "isOneOf": false,
+        "name": "BubbleRelationFilter",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
               },
             ],
             "name": "equals",
@@ -1949,10 +3411,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": true,
-                "isNullable": false,
+                "isNullable": true,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "Int",
+                "type": "String",
               },
             ],
             "name": "in",
@@ -1961,10 +3423,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": true,
-                "isNullable": false,
+                "isNullable": true,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "Int",
+                "type": "String",
               },
             ],
             "name": "notIn",
@@ -1973,10 +3435,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": false,
+                "isNullable": true,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "Int",
+                "type": "String",
               },
             ],
             "name": "lt",
@@ -1985,10 +3447,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": false,
+                "isNullable": true,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "Int",
+                "type": "String",
               },
             ],
             "name": "lte",
@@ -1997,10 +3459,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": false,
+                "isNullable": true,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "Int",
+                "type": "String",
               },
             ],
             "name": "gt",
@@ -2009,10 +3471,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": false,
+                "isNullable": true,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "Int",
+                "type": "String",
               },
             ],
             "name": "gte",
@@ -2023,15 +3485,58 @@ Object {
                 "isList": false,
                 "isNullable": true,
                 "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "contains",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "startsWith",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "endsWith",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
                 "kind": "object",
-                "type": "NestedIntFilter",
+                "type": "NestedStringNullableFilter",
               },
             ],
             "name": "not",
           },
         ],
         "isOneOf": false,
-        "name": "NestedIntFilter",
+        "name": "StringNullableFilter",
       },
       Object {
         "fields": Array [
@@ -2232,108 +3737,6 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "NestedFloatFilter",
-              },
-            ],
-            "name": "not",
-          },
-        ],
-        "isOneOf": false,
-        "name": "NestedFloatFilter",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "equals",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "in",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "notIn",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "lt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "lte",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "gt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "gte",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
@@ -2352,60 +3755,6 @@ Object {
         ],
         "isOneOf": false,
         "name": "FloatFilter",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "PostStatus",
-              },
-            ],
-            "name": "equals",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "PostStatus",
-              },
-            ],
-            "name": "in",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "PostStatus",
-              },
-            ],
-            "name": "notIn",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "NestedEnumPostStatusFilter",
-              },
-            ],
-            "name": "not",
-          },
-        ],
-        "isOneOf": false,
-        "name": "NestedEnumPostStatusFilter",
       },
       Object {
         "fields": Array [
@@ -2477,10 +3826,10 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "PostWhereInput",
+                "type": "UserCreateWithoutBubbleInput",
               },
             ],
-            "name": "AND",
+            "name": "create",
           },
           Object {
             "inputType": Array [
@@ -2489,10 +3838,85 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "PostWhereInput",
+                "type": "UserWhereUniqueInput",
               },
             ],
-            "name": "OR",
+            "name": "connect",
+          },
+        ],
+        "isOneOf": false,
+        "name": "UserCreateManyWithoutBubbleInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "set",
+          },
+        ],
+        "isOneOf": true,
+        "isUpdateOperationType": true,
+        "name": "StringFieldUpdateOperationsInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+            ],
+            "name": "set",
+          },
+        ],
+        "isOneOf": true,
+        "isUpdateOperationType": true,
+        "name": "DateTimeFieldUpdateOperationsInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Boolean",
+              },
+            ],
+            "name": "set",
+          },
+        ],
+        "isOneOf": true,
+        "isUpdateOperationType": true,
+        "name": "BoolFieldUpdateOperationsInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserCreateWithoutBubbleInput",
+              },
+            ],
+            "name": "create",
           },
           Object {
             "inputType": Array [
@@ -2501,10 +3925,382 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "PostWhereInput",
+                "type": "UserWhereUniqueInput",
               },
             ],
-            "name": "NOT",
+            "name": "connect",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "set",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "disconnect",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "delete",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpdateWithWhereUniqueWithoutBubbleInput",
+              },
+            ],
+            "name": "update",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpdateManyWithWhereNestedInput",
+              },
+            ],
+            "name": "updateMany",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserScalarWhereInput",
+              },
+            ],
+            "name": "deleteMany",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpsertWithWhereUniqueWithoutBubbleInput",
+              },
+            ],
+            "name": "upsert",
+          },
+        ],
+        "isOneOf": false,
+        "name": "UserUpdateManyWithoutBubbleInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostCreateWithoutAuthorsInput",
+              },
+            ],
+            "name": "create",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereUniqueInput",
+              },
+            ],
+            "name": "connect",
+          },
+        ],
+        "isOneOf": false,
+        "name": "PostCreateManyWithoutAuthorsInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationCreateWithoutUserInput",
+              },
+            ],
+            "name": "create",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationWhereUniqueInput",
+              },
+            ],
+            "name": "connect",
+          },
+        ],
+        "isOneOf": false,
+        "name": "LocationCreateOneWithoutUserInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleCreateWithoutMembersInput",
+              },
+            ],
+            "name": "create",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleWhereUniqueInput",
+              },
+            ],
+            "name": "connect",
+          },
+        ],
+        "isOneOf": false,
+        "name": "BubbleCreateOneWithoutMembersInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostCreateWithoutAuthorsInput",
+              },
+            ],
+            "name": "create",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereUniqueInput",
+              },
+            ],
+            "name": "connect",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereUniqueInput",
+              },
+            ],
+            "name": "set",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereUniqueInput",
+              },
+            ],
+            "name": "disconnect",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostWhereUniqueInput",
+              },
+            ],
+            "name": "delete",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostUpdateWithWhereUniqueWithoutAuthorsInput",
+              },
+            ],
+            "name": "update",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostUpdateManyWithWhereNestedInput",
+              },
+            ],
+            "name": "updateMany",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostScalarWhereInput",
+              },
+            ],
+            "name": "deleteMany",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostUpsertWithWhereUniqueWithoutAuthorsInput",
+              },
+            ],
+            "name": "upsert",
+          },
+        ],
+        "isOneOf": false,
+        "name": "PostUpdateManyWithoutAuthorsInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationCreateWithoutUserInput",
+              },
+            ],
+            "name": "create",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationWhereUniqueInput",
+              },
+            ],
+            "name": "connect",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationUpdateWithoutUserDataInput",
+              },
+            ],
+            "name": "update",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationUpsertWithoutUserInput",
+              },
+            ],
+            "name": "upsert",
+          },
+        ],
+        "isOneOf": false,
+        "name": "LocationUpdateOneRequiredWithoutUserInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleCreateWithoutMembersInput",
+              },
+            ],
+            "name": "create",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleWhereUniqueInput",
+              },
+            ],
+            "name": "connect",
           },
           Object {
             "inputType": Array [
@@ -2513,17 +4309,22 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "Int",
+                "type": "Boolean",
               },
+            ],
+            "name": "disconnect",
+          },
+          Object {
+            "inputType": Array [
               Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
-                "kind": "object",
-                "type": "IntFilter",
+                "kind": "scalar",
+                "type": "Boolean",
               },
             ],
-            "name": "id",
+            "name": "delete",
           },
           Object {
             "inputType": Array [
@@ -2532,11 +4333,203 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "UserListRelationFilter",
+                "type": "BubbleUpdateWithoutMembersDataInput",
               },
             ],
-            "name": "authors",
+            "name": "update",
           },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleUpsertWithoutMembersInput",
+              },
+            ],
+            "name": "upsert",
+          },
+        ],
+        "isOneOf": false,
+        "name": "BubbleUpdateOneWithoutMembersInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserCreateWithoutLocationInput",
+              },
+            ],
+            "name": "create",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "connect",
+          },
+        ],
+        "isOneOf": false,
+        "name": "UserCreateManyWithoutLocationInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserCreateWithoutLocationInput",
+              },
+            ],
+            "name": "create",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "connect",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "set",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "disconnect",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "delete",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpdateWithWhereUniqueWithoutLocationInput",
+              },
+            ],
+            "name": "update",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpdateManyWithWhereNestedInput",
+              },
+            ],
+            "name": "updateMany",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserScalarWhereInput",
+              },
+            ],
+            "name": "deleteMany",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpsertWithWhereUniqueWithoutLocationInput",
+              },
+            ],
+            "name": "upsert",
+          },
+        ],
+        "isOneOf": false,
+        "name": "UserUpdateManyWithoutLocationInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserCreateWithoutPostsInput",
+              },
+            ],
+            "name": "create",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "connect",
+          },
+        ],
+        "isOneOf": false,
+        "name": "UserCreateManyWithoutPostsInput",
+      },
+      Object {
+        "fields": Array [
           Object {
             "inputType": Array [
               Object {
@@ -2546,16 +4539,16 @@ Object {
                 "kind": "scalar",
                 "type": "Float",
               },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "FloatFilter",
-              },
             ],
-            "name": "rating",
+            "name": "set",
           },
+        ],
+        "isOneOf": true,
+        "isUpdateOperationType": true,
+        "name": "FloatFieldUpdateOperationsInput",
+      },
+      Object {
+        "fields": Array [
           Object {
             "inputType": Array [
               Object {
@@ -2565,62 +4558,13 @@ Object {
                 "kind": "enum",
                 "type": "PostStatus",
               },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "EnumPostStatusFilter",
-              },
             ],
-            "name": "status",
+            "name": "set",
           },
         ],
-        "isOneOf": false,
-        "isWhereType": true,
-        "name": "PostWhereInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostWhereInput",
-              },
-            ],
-            "name": "every",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostWhereInput",
-              },
-            ],
-            "name": "some",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostWhereInput",
-              },
-            ],
-            "name": "none",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostListRelationFilter",
+        "isOneOf": true,
+        "isUpdateOperationType": true,
+        "name": "EnumPostStatusFieldUpdateOperationsInput",
       },
       Object {
         "fields": Array [
@@ -2631,10 +4575,10 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "LocationWhereInput",
+                "type": "UserCreateWithoutPostsInput",
               },
             ],
-            "name": "AND",
+            "name": "create",
           },
           Object {
             "inputType": Array [
@@ -2643,10 +4587,10 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "LocationWhereInput",
+                "type": "UserWhereUniqueInput",
               },
             ],
-            "name": "OR",
+            "name": "connect",
           },
           Object {
             "inputType": Array [
@@ -2655,11 +4599,89 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "LocationWhereInput",
+                "type": "UserWhereUniqueInput",
               },
             ],
-            "name": "NOT",
+            "name": "set",
           },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "disconnect",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserWhereUniqueInput",
+              },
+            ],
+            "name": "delete",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpdateWithWhereUniqueWithoutPostsInput",
+              },
+            ],
+            "name": "update",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpdateManyWithWhereNestedInput",
+              },
+            ],
+            "name": "updateMany",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserScalarWhereInput",
+              },
+            ],
+            "name": "deleteMany",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "UserUpsertWithWhereUniqueWithoutPostsInput",
+              },
+            ],
+            "name": "upsert",
+          },
+        ],
+        "isOneOf": false,
+        "name": "UserUpdateManyWithoutPostsInput",
+      },
+      Object {
+        "fields": Array [
           Object {
             "inputType": Array [
               Object {
@@ -2667,17 +4689,34 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "Int",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "IntFilter",
+                "type": "String",
               },
             ],
-            "name": "id",
+            "name": "equals",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "in",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "notIn",
           },
           Object {
             "inputType": Array [
@@ -2688,15 +4727,8 @@ Object {
                 "kind": "scalar",
                 "type": "String",
               },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "StringFilter",
-              },
             ],
-            "name": "country",
+            "name": "lt",
           },
           Object {
             "inputType": Array [
@@ -2707,15 +4739,8 @@ Object {
                 "kind": "scalar",
                 "type": "String",
               },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "StringFilter",
-              },
             ],
-            "name": "city",
+            "name": "lte",
           },
           Object {
             "inputType": Array [
@@ -2723,16 +4748,75 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
-                "kind": "object",
-                "type": "UserListRelationFilter",
+                "kind": "scalar",
+                "type": "String",
               },
             ],
-            "name": "User",
+            "name": "gt",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "gte",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "contains",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "startsWith",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "String",
+              },
+            ],
+            "name": "endsWith",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "NestedStringFilter",
+              },
+            ],
+            "name": "not",
           },
         ],
         "isOneOf": false,
-        "isWhereType": true,
-        "name": "LocationWhereInput",
+        "name": "NestedStringFilter",
       },
       Object {
         "fields": Array [
@@ -2740,13 +4824,85 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": true,
+                "isNullable": false,
                 "isRequired": false,
-                "kind": "object",
-                "type": "LocationWhereInput",
+                "kind": "scalar",
+                "type": "DateTime",
               },
             ],
-            "name": "is",
+            "name": "equals",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+            ],
+            "name": "in",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+            ],
+            "name": "notIn",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+            ],
+            "name": "lt",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+            ],
+            "name": "lte",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+            ],
+            "name": "gt",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "DateTime",
+              },
+            ],
+            "name": "gte",
           },
           Object {
             "inputType": Array [
@@ -2755,14 +4911,14 @@ Object {
                 "isNullable": true,
                 "isRequired": false,
                 "kind": "object",
-                "type": "LocationWhereInput",
+                "type": "NestedDateTimeFilter",
               },
             ],
-            "name": "isNot",
+            "name": "not",
           },
         ],
         "isOneOf": false,
-        "name": "LocationRelationFilter",
+        "name": "NestedDateTimeFilter",
       },
       Object {
         "fields": Array [
@@ -2770,13 +4926,13 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": true,
+                "isNullable": false,
                 "isRequired": false,
-                "kind": "object",
-                "type": "BubbleWhereInput",
+                "kind": "scalar",
+                "type": "Boolean",
               },
             ],
-            "name": "is",
+            "name": "equals",
           },
           Object {
             "inputType": Array [
@@ -2785,14 +4941,14 @@ Object {
                 "isNullable": true,
                 "isRequired": false,
                 "kind": "object",
-                "type": "BubbleWhereInput",
+                "type": "NestedBoolFilter",
               },
             ],
-            "name": "isNot",
+            "name": "not",
           },
         ],
         "isOneOf": false,
-        "name": "BubbleRelationFilter",
+        "name": "NestedBoolFilter",
       },
       Object {
         "fields": Array [
@@ -2938,10 +5094,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": true,
+                "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "String",
+                "type": "Int",
               },
             ],
             "name": "equals",
@@ -2950,10 +5106,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": true,
-                "isNullable": true,
+                "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "String",
+                "type": "Int",
               },
             ],
             "name": "in",
@@ -2962,10 +5118,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": true,
-                "isNullable": true,
+                "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "String",
+                "type": "Int",
               },
             ],
             "name": "notIn",
@@ -2974,10 +5130,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": true,
+                "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "String",
+                "type": "Int",
               },
             ],
             "name": "lt",
@@ -2986,10 +5142,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": true,
+                "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "String",
+                "type": "Int",
               },
             ],
             "name": "lte",
@@ -2998,10 +5154,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": true,
+                "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "String",
+                "type": "Int",
               },
             ],
             "name": "gt",
@@ -3010,10 +5166,10 @@ Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": true,
+                "isNullable": false,
                 "isRequired": false,
                 "kind": "scalar",
-                "type": "String",
+                "type": "Int",
               },
             ],
             "name": "gte",
@@ -3024,239 +5180,15 @@ Object {
                 "isList": false,
                 "isNullable": true,
                 "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "contains",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "startsWith",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "endsWith",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
                 "kind": "object",
-                "type": "NestedStringNullableFilter",
+                "type": "NestedIntFilter",
               },
             ],
             "name": "not",
           },
         ],
         "isOneOf": false,
-        "name": "StringNullableFilter",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereInput",
-              },
-            ],
-            "name": "AND",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereInput",
-              },
-            ],
-            "name": "OR",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereInput",
-              },
-            ],
-            "name": "NOT",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "StringFilter",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostListRelationFilter",
-              },
-            ],
-            "name": "posts",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "StringFilter",
-              },
-            ],
-            "name": "firstName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "StringFilter",
-              },
-            ],
-            "name": "lastName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "LocationWhereInput",
-              },
-            ],
-            "name": "location",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleWhereInput",
-              },
-            ],
-            "name": "Bubble",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "StringNullableFilter",
-              },
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "null",
-              },
-            ],
-            "name": "bubbleId",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Int",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "IntFilter",
-              },
-            ],
-            "name": "locationId",
-          },
-        ],
-        "isOneOf": false,
-        "isWhereType": true,
-        "name": "UserWhereInput",
+        "name": "NestedIntFilter",
       },
       Object {
         "fields": Array [
@@ -3266,534 +5198,113 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereInput",
-              },
-            ],
-            "name": "every",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereInput",
-              },
-            ],
-            "name": "some",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereInput",
-              },
-            ],
-            "name": "none",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserListRelationFilter",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Boolean",
-              },
-            ],
-            "name": "equals",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "NestedBoolFilter",
-              },
-            ],
-            "name": "not",
-          },
-        ],
-        "isOneOf": false,
-        "name": "NestedBoolFilter",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Boolean",
-              },
-            ],
-            "name": "equals",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Boolean",
-              },
-              Object {
-                "isList": false,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "NestedBoolFilter",
-              },
-            ],
-            "name": "not",
-          },
-        ],
-        "isOneOf": false,
-        "name": "BoolFilter",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleWhereInput",
-              },
-            ],
-            "name": "AND",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleWhereInput",
-              },
-            ],
-            "name": "OR",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleWhereInput",
-              },
-            ],
-            "name": "NOT",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "StringFilter",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "DateTimeFilter",
-              },
-            ],
-            "name": "createdAt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserListRelationFilter",
-              },
-            ],
-            "name": "members",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Boolean",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BoolFilter",
-              },
-            ],
-            "name": "private",
-          },
-        ],
-        "isOneOf": false,
-        "isWhereType": true,
-        "name": "BubbleWhereInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "createdAt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "private",
-          },
-        ],
-        "isOneOf": true,
-        "isOrderType": true,
-        "name": "BubbleOrderByInput",
-      },
-      Object {
-        "atLeastOne": true,
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "id",
-          },
-        ],
-        "isOneOf": true,
-        "name": "BubbleWhereUniqueInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "firstName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "lastName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "bubbleId",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "locationId",
-          },
-        ],
-        "isOneOf": true,
-        "isOrderType": true,
-        "name": "UserOrderByInput",
-      },
-      Object {
-        "atLeastOne": true,
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "id",
-          },
-        ],
-        "isOneOf": true,
-        "name": "UserWhereUniqueInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "rating",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "status",
-          },
-        ],
-        "isOneOf": true,
-        "isOrderType": true,
-        "name": "PostOrderByInput",
-      },
-      Object {
-        "atLeastOne": true,
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Int",
-              },
-            ],
-            "name": "id",
-          },
-        ],
-        "isOneOf": true,
-        "name": "PostWhereUniqueInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "country",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "SortOrder",
-              },
-            ],
-            "name": "city",
-          },
-        ],
-        "isOneOf": true,
-        "isOrderType": true,
-        "name": "LocationOrderByInput",
-      },
-      Object {
-        "atLeastOne": true,
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Int",
-              },
-            ],
-            "name": "id",
-          },
-        ],
-        "isOneOf": true,
-        "name": "LocationWhereUniqueInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
                 "kind": "scalar",
                 "type": "Float",
               },
             ],
-            "name": "rating",
+            "name": "equals",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "in",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "notIn",
           },
           Object {
             "inputType": Array [
               Object {
                 "isList": false,
                 "isNullable": false,
-                "isRequired": true,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "lt",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "lte",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "gt",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+            ],
+            "name": "gte",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": true,
+                "isRequired": false,
+                "kind": "object",
+                "type": "NestedFloatFilter",
+              },
+            ],
+            "name": "not",
+          },
+        ],
+        "isOneOf": false,
+        "name": "NestedFloatFilter",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
                 "kind": "enum",
                 "type": "PostStatus",
               },
             ],
-            "name": "status",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostCreateWithoutAuthorsInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostCreateWithoutAuthorsInput",
-              },
-            ],
-            "name": "create",
+            "name": "equals",
           },
           Object {
             "inputType": Array [
@@ -3801,75 +5312,39 @@ Object {
                 "isList": true,
                 "isNullable": false,
                 "isRequired": false,
-                "kind": "object",
-                "type": "PostWhereUniqueInput",
+                "kind": "enum",
+                "type": "PostStatus",
               },
             ],
-            "name": "connect",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostCreateManyWithoutAuthorsInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "country",
+            "name": "in",
           },
           Object {
             "inputType": Array [
               Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "city",
-          },
-        ],
-        "isOneOf": false,
-        "name": "LocationCreateWithoutUserInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
+                "isList": true,
                 "isNullable": false,
                 "isRequired": false,
-                "kind": "object",
-                "type": "LocationCreateWithoutUserInput",
+                "kind": "enum",
+                "type": "PostStatus",
               },
             ],
-            "name": "create",
+            "name": "notIn",
           },
           Object {
             "inputType": Array [
               Object {
                 "isList": false,
-                "isNullable": false,
+                "isNullable": true,
                 "isRequired": false,
                 "kind": "object",
-                "type": "LocationWhereUniqueInput",
+                "type": "NestedEnumPostStatusFilter",
               },
             ],
-            "name": "connect",
+            "name": "not",
           },
         ],
         "isOneOf": false,
-        "name": "LocationCreateOneWithoutUserInput",
+        "name": "NestedEnumPostStatusFilter",
       },
       Object {
         "fields": Array [
@@ -3942,646 +5417,6 @@ Object {
           Object {
             "inputType": Array [
               Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserCreateWithoutBubbleInput",
-              },
-            ],
-            "name": "create",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "connect",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserCreateManyWithoutBubbleInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "createdAt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "scalar",
-                "type": "Boolean",
-              },
-            ],
-            "name": "private",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserCreateManyWithoutBubbleInput",
-              },
-            ],
-            "name": "members",
-          },
-        ],
-        "isOneOf": false,
-        "name": "BubbleCreateInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "rating",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "PostStatus",
-              },
-            ],
-            "name": "status",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostUpdateWithoutAuthorsDataInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "PostWhereUniqueInput",
-              },
-            ],
-            "name": "where",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "PostUpdateWithoutAuthorsDataInput",
-              },
-            ],
-            "name": "data",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostUpdateWithWhereUniqueWithoutAuthorsInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostScalarWhereInput",
-              },
-            ],
-            "name": "AND",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostScalarWhereInput",
-              },
-            ],
-            "name": "OR",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostScalarWhereInput",
-              },
-            ],
-            "name": "NOT",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Int",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "IntFilter",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "FloatFilter",
-              },
-            ],
-            "name": "rating",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "PostStatus",
-              },
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "EnumPostStatusFilter",
-              },
-            ],
-            "name": "status",
-          },
-        ],
-        "isOneOf": false,
-        "isWhereType": true,
-        "name": "PostScalarWhereInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "rating",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "PostStatus",
-              },
-            ],
-            "name": "status",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostUpdateManyDataInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "PostScalarWhereInput",
-              },
-            ],
-            "name": "where",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "PostUpdateManyDataInput",
-              },
-            ],
-            "name": "data",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostUpdateManyWithWhereNestedInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "PostWhereUniqueInput",
-              },
-            ],
-            "name": "where",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "PostUpdateWithoutAuthorsDataInput",
-              },
-            ],
-            "name": "update",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "PostCreateWithoutAuthorsInput",
-              },
-            ],
-            "name": "create",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostUpsertWithWhereUniqueWithoutAuthorsInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostCreateWithoutAuthorsInput",
-              },
-            ],
-            "name": "create",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostWhereUniqueInput",
-              },
-            ],
-            "name": "connect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostWhereUniqueInput",
-              },
-            ],
-            "name": "set",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostWhereUniqueInput",
-              },
-            ],
-            "name": "disconnect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostWhereUniqueInput",
-              },
-            ],
-            "name": "delete",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostUpdateWithWhereUniqueWithoutAuthorsInput",
-              },
-            ],
-            "name": "update",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostUpdateManyWithWhereNestedInput",
-              },
-            ],
-            "name": "updateMany",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostScalarWhereInput",
-              },
-            ],
-            "name": "deleteMany",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostUpsertWithWhereUniqueWithoutAuthorsInput",
-              },
-            ],
-            "name": "upsert",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostUpdateManyWithoutAuthorsInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "country",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "city",
-          },
-        ],
-        "isOneOf": false,
-        "name": "LocationUpdateWithoutUserDataInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "LocationUpdateWithoutUserDataInput",
-              },
-            ],
-            "name": "update",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "LocationCreateWithoutUserInput",
-              },
-            ],
-            "name": "create",
-          },
-        ],
-        "isOneOf": false,
-        "name": "LocationUpsertWithoutUserInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "LocationCreateWithoutUserInput",
-              },
-            ],
-            "name": "create",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "LocationWhereUniqueInput",
-              },
-            ],
-            "name": "connect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "LocationUpdateWithoutUserDataInput",
-              },
-            ],
-            "name": "update",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "LocationUpsertWithoutUserInput",
-              },
-            ],
-            "name": "upsert",
-          },
-        ],
-        "isOneOf": false,
-        "name": "LocationUpdateOneRequiredWithoutUserInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "firstName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "lastName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostUpdateManyWithoutAuthorsInput",
-              },
-            ],
-            "name": "posts",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "LocationUpdateOneRequiredWithoutUserInput",
-              },
-            ],
-            "name": "location",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserUpdateWithoutBubbleDataInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": true,
@@ -4606,6 +5441,36 @@ Object {
         ],
         "isOneOf": false,
         "name": "UserUpdateWithWhereUniqueWithoutBubbleInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "UserScalarWhereInput",
+              },
+            ],
+            "name": "where",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "UserUpdateManyDataInput",
+              },
+            ],
+            "name": "data",
+          },
+        ],
+        "isOneOf": false,
+        "name": "UserUpdateManyWithWhereNestedInput",
       },
       Object {
         "fields": Array [
@@ -4759,78 +5624,6 @@ Object {
               Object {
                 "isList": false,
                 "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "firstName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "lastName",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserUpdateManyDataInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "UserScalarWhereInput",
-              },
-            ],
-            "name": "where",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "UserUpdateManyDataInput",
-              },
-            ],
-            "name": "data",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserUpdateManyWithWhereNestedInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
                 "isRequired": true,
                 "kind": "object",
                 "type": "UserWhereUniqueInput",
@@ -4871,114 +5664,30 @@ Object {
           Object {
             "inputType": Array [
               Object {
-                "isList": true,
+                "isList": false,
                 "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserCreateWithoutBubbleInput",
+                "isRequired": true,
+                "kind": "scalar",
+                "type": "Float",
               },
             ],
-            "name": "create",
+            "name": "rating",
           },
           Object {
             "inputType": Array [
               Object {
-                "isList": true,
+                "isList": false,
                 "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
+                "isRequired": true,
+                "kind": "enum",
+                "type": "PostStatus",
               },
             ],
-            "name": "connect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "set",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "disconnect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "delete",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpdateWithWhereUniqueWithoutBubbleInput",
-              },
-            ],
-            "name": "update",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpdateManyWithWhereNestedInput",
-              },
-            ],
-            "name": "updateMany",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserScalarWhereInput",
-              },
-            ],
-            "name": "deleteMany",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpsertWithWhereUniqueWithoutBubbleInput",
-              },
-            ],
-            "name": "upsert",
+            "name": "status",
           },
         ],
         "isOneOf": false,
-        "name": "UserUpdateManyWithoutBubbleInput",
+        "name": "PostCreateWithoutAuthorsInput",
       },
       Object {
         "fields": Array [
@@ -4987,94 +5696,28 @@ Object {
               Object {
                 "isList": false,
                 "isNullable": false,
-                "isRequired": false,
+                "isRequired": true,
                 "kind": "scalar",
                 "type": "String",
               },
             ],
-            "name": "id",
+            "name": "country",
           },
           Object {
             "inputType": Array [
               Object {
                 "isList": false,
                 "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "createdAt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Boolean",
-              },
-            ],
-            "name": "private",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpdateManyWithoutBubbleInput",
-              },
-            ],
-            "name": "members",
-          },
-        ],
-        "isOneOf": false,
-        "name": "BubbleUpdateInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
+                "isRequired": true,
                 "kind": "scalar",
                 "type": "String",
               },
             ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
-              },
-            ],
-            "name": "createdAt",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Boolean",
-              },
-            ],
-            "name": "private",
+            "name": "city",
           },
         ],
         "isOneOf": false,
-        "name": "BubbleUpdateManyMutationInput",
+        "name": "LocationCreateWithoutUserInput",
       },
       Object {
         "fields": Array [
@@ -5125,28 +5768,200 @@ Object {
               Object {
                 "isList": false,
                 "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "PostWhereUniqueInput",
+              },
+            ],
+            "name": "where",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "PostUpdateWithoutAuthorsDataInput",
+              },
+            ],
+            "name": "data",
+          },
+        ],
+        "isOneOf": false,
+        "name": "PostUpdateWithWhereUniqueWithoutAuthorsInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "PostScalarWhereInput",
+              },
+            ],
+            "name": "where",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "PostUpdateManyDataInput",
+              },
+            ],
+            "name": "data",
+          },
+        ],
+        "isOneOf": false,
+        "name": "PostUpdateManyWithWhereNestedInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "BubbleCreateWithoutMembersInput",
+                "type": "PostScalarWhereInput",
+              },
+            ],
+            "name": "AND",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostScalarWhereInput",
+              },
+            ],
+            "name": "OR",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": true,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostScalarWhereInput",
+              },
+            ],
+            "name": "NOT",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Int",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "IntFilter",
+              },
+            ],
+            "name": "id",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "scalar",
+                "type": "Float",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "FloatFilter",
+              },
+            ],
+            "name": "rating",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "enum",
+                "type": "PostStatus",
+              },
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "EnumPostStatusFilter",
+              },
+            ],
+            "name": "status",
+          },
+        ],
+        "isOneOf": false,
+        "isWhereType": true,
+        "name": "PostScalarWhereInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "PostWhereUniqueInput",
+              },
+            ],
+            "name": "where",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "PostUpdateWithoutAuthorsDataInput",
+              },
+            ],
+            "name": "update",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "PostCreateWithoutAuthorsInput",
               },
             ],
             "name": "create",
           },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleWhereUniqueInput",
-              },
-            ],
-            "name": "connect",
-          },
         ],
         "isOneOf": false,
-        "name": "BubbleCreateOneWithoutMembersInput",
+        "name": "PostUpsertWithWhereUniqueWithoutAuthorsInput",
       },
       Object {
         "fields": Array [
@@ -5156,35 +5971,11 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
               },
             ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "firstName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "lastName",
+            "name": "country",
           },
           Object {
             "inputType": Array [
@@ -5193,38 +5984,44 @@ Object {
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "PostCreateManyWithoutAuthorsInput",
+                "type": "StringFieldUpdateOperationsInput",
               },
             ],
-            "name": "posts",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "object",
-                "type": "LocationCreateOneWithoutUserInput",
-              },
-            ],
-            "name": "location",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleCreateOneWithoutMembersInput",
-              },
-            ],
-            "name": "Bubble",
+            "name": "city",
           },
         ],
         "isOneOf": false,
-        "name": "UserCreateInput",
+        "name": "LocationUpdateWithoutUserDataInput",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "LocationUpdateWithoutUserDataInput",
+              },
+            ],
+            "name": "update",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": true,
+                "kind": "object",
+                "type": "LocationCreateWithoutUserInput",
+              },
+            ],
+            "name": "create",
+          },
+        ],
+        "isOneOf": false,
+        "name": "LocationUpsertWithoutUserInput",
       },
       Object {
         "fields": Array [
@@ -5234,8 +6031,8 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
               },
             ],
             "name": "id",
@@ -5246,8 +6043,8 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
-                "kind": "scalar",
-                "type": "DateTime",
+                "kind": "object",
+                "type": "DateTimeFieldUpdateOperationsInput",
               },
             ],
             "name": "createdAt",
@@ -5258,8 +6055,8 @@ Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
-                "kind": "scalar",
-                "type": "Boolean",
+                "kind": "object",
+                "type": "BoolFieldUpdateOperationsInput",
               },
             ],
             "name": "private",
@@ -5297,204 +6094,6 @@ Object {
         ],
         "isOneOf": false,
         "name": "BubbleUpsertWithoutMembersInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleCreateWithoutMembersInput",
-              },
-            ],
-            "name": "create",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleWhereUniqueInput",
-              },
-            ],
-            "name": "connect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Boolean",
-              },
-            ],
-            "name": "disconnect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Boolean",
-              },
-            ],
-            "name": "delete",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleUpdateWithoutMembersDataInput",
-              },
-            ],
-            "name": "update",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleUpsertWithoutMembersInput",
-              },
-            ],
-            "name": "upsert",
-          },
-        ],
-        "isOneOf": false,
-        "name": "BubbleUpdateOneWithoutMembersInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "firstName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "lastName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostUpdateManyWithoutAuthorsInput",
-              },
-            ],
-            "name": "posts",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "LocationUpdateOneRequiredWithoutUserInput",
-              },
-            ],
-            "name": "location",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleUpdateOneWithoutMembersInput",
-              },
-            ],
-            "name": "Bubble",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserUpdateInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "firstName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "lastName",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserUpdateManyMutationInput",
       },
       Object {
         "fields": Array [
@@ -5561,144 +6160,6 @@ Object {
         ],
         "isOneOf": false,
         "name": "UserCreateWithoutLocationInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserCreateWithoutLocationInput",
-              },
-            ],
-            "name": "create",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "connect",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserCreateManyWithoutLocationInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "country",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "city",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserCreateManyWithoutLocationInput",
-              },
-            ],
-            "name": "User",
-          },
-        ],
-        "isOneOf": false,
-        "name": "LocationCreateInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "firstName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "lastName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "PostUpdateManyWithoutAuthorsInput",
-              },
-            ],
-            "name": "posts",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleUpdateOneWithoutMembersInput",
-              },
-            ],
-            "name": "Bubble",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserUpdateWithoutLocationDataInput",
       },
       Object {
         "fields": Array [
@@ -5777,192 +6238,6 @@ Object {
           Object {
             "inputType": Array [
               Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserCreateWithoutLocationInput",
-              },
-            ],
-            "name": "create",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "connect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "set",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "disconnect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "delete",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpdateWithWhereUniqueWithoutLocationInput",
-              },
-            ],
-            "name": "update",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpdateManyWithWhereNestedInput",
-              },
-            ],
-            "name": "updateMany",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserScalarWhereInput",
-              },
-            ],
-            "name": "deleteMany",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpsertWithWhereUniqueWithoutLocationInput",
-              },
-            ],
-            "name": "upsert",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserUpdateManyWithoutLocationInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "country",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "city",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpdateManyWithoutLocationInput",
-              },
-            ],
-            "name": "User",
-          },
-        ],
-        "isOneOf": false,
-        "name": "LocationUpdateInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "country",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "city",
-          },
-        ],
-        "isOneOf": false,
-        "name": "LocationUpdateManyMutationInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
@@ -6023,144 +6298,6 @@ Object {
         ],
         "isOneOf": false,
         "name": "UserCreateWithoutPostsInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserCreateWithoutPostsInput",
-              },
-            ],
-            "name": "create",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "connect",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserCreateManyWithoutPostsInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "rating",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": true,
-                "kind": "enum",
-                "type": "PostStatus",
-              },
-            ],
-            "name": "status",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserCreateManyWithoutPostsInput",
-              },
-            ],
-            "name": "authors",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostCreateInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "id",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "firstName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "String",
-              },
-            ],
-            "name": "lastName",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "LocationUpdateOneRequiredWithoutUserInput",
-              },
-            ],
-            "name": "location",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "BubbleUpdateOneWithoutMembersInput",
-              },
-            ],
-            "name": "Bubble",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserUpdateWithoutPostsDataInput",
       },
       Object {
         "fields": Array [
@@ -6239,1153 +6376,303 @@ Object {
           Object {
             "inputType": Array [
               Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserCreateWithoutPostsInput",
-              },
-            ],
-            "name": "create",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "connect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "set",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "disconnect",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserWhereUniqueInput",
-              },
-            ],
-            "name": "delete",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpdateWithWhereUniqueWithoutPostsInput",
-              },
-            ],
-            "name": "update",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": true,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpdateManyWithWhereNestedInput",
-              },
-            ],
-            "name": "updateMany",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserScalarWhereInput",
-              },
-            ],
-            "name": "deleteMany",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": true,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "object",
-                "type": "UserUpsertWithWhereUniqueWithoutPostsInput",
-              },
-            ],
-            "name": "upsert",
-          },
-        ],
-        "isOneOf": false,
-        "name": "UserUpdateManyWithoutPostsInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "rating",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "PostStatus",
-              },
-            ],
-            "name": "status",
-          },
-          Object {
-            "inputType": Array [
-              Object {
                 "isList": false,
                 "isNullable": false,
                 "isRequired": false,
                 "kind": "object",
-                "type": "UserUpdateManyWithoutPostsInput",
+                "type": "StringFieldUpdateOperationsInput",
               },
             ],
-            "name": "authors",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostUpdateInput",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "scalar",
-                "type": "Float",
-              },
-            ],
-            "name": "rating",
-          },
-          Object {
-            "inputType": Array [
-              Object {
-                "isList": false,
-                "isNullable": false,
-                "isRequired": false,
-                "kind": "enum",
-                "type": "PostStatus",
-              },
-            ],
-            "name": "status",
-          },
-        ],
-        "isOneOf": false,
-        "name": "PostUpdateManyMutationInput",
-      },
-    ],
-    "outputTypes": Array [
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
             "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
           },
           Object {
-            "args": Array [
+            "inputType": Array [
               Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "UserWhereInput",
-                  },
-                ],
-                "name": "where",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": true,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "UserOrderByInput",
-                  },
-                ],
-                "name": "orderBy",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "UserWhereUniqueInput",
-                  },
-                ],
-                "name": "cursor",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "scalar",
-                    "type": "Int",
-                  },
-                ],
-                "name": "take",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "scalar",
-                    "type": "Int",
-                  },
-                ],
-                "name": "skip",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": true,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "enum",
-                    "type": "UserDistinctFieldEnum",
-                  },
-                ],
-                "name": "distinct",
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
               },
             ],
-            "name": "authors",
-            "outputType": Object {
-              "isList": true,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "User",
-            },
+            "name": "firstName",
           },
           Object {
-            "args": Array [],
-            "name": "rating",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Float",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "status",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "enum",
-              "type": "PostStatus",
-            },
-          },
-        ],
-        "name": "Post",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "country",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "String",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "city",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "String",
-            },
-          },
-          Object {
-            "args": Array [
+            "inputType": Array [
               Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "UserWhereInput",
-                  },
-                ],
-                "name": "where",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": true,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "UserOrderByInput",
-                  },
-                ],
-                "name": "orderBy",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "UserWhereUniqueInput",
-                  },
-                ],
-                "name": "cursor",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "scalar",
-                    "type": "Int",
-                  },
-                ],
-                "name": "take",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "scalar",
-                    "type": "Int",
-                  },
-                ],
-                "name": "skip",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": true,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "enum",
-                    "type": "UserDistinctFieldEnum",
-                  },
-                ],
-                "name": "distinct",
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
               },
             ],
-            "name": "User",
-            "outputType": Object {
-              "isList": true,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "User",
-            },
-          },
-        ],
-        "name": "Location",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "String",
-            },
+            "name": "lastName",
           },
           Object {
-            "args": Array [
+            "inputType": Array [
               Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "PostWhereInput",
-                  },
-                ],
-                "name": "where",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": true,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "PostOrderByInput",
-                  },
-                ],
-                "name": "orderBy",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "PostWhereUniqueInput",
-                  },
-                ],
-                "name": "cursor",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "scalar",
-                    "type": "Int",
-                  },
-                ],
-                "name": "take",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "scalar",
-                    "type": "Int",
-                  },
-                ],
-                "name": "skip",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": true,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "enum",
-                    "type": "PostDistinctFieldEnum",
-                  },
-                ],
-                "name": "distinct",
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostUpdateManyWithoutAuthorsInput",
               },
             ],
             "name": "posts",
-            "outputType": Object {
-              "isList": true,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "Post",
-            },
           },
           Object {
-            "args": Array [],
-            "name": "firstName",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "String",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "lastName",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "String",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "location",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "object",
-              "type": "Location",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "Bubble",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "Bubble",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "bubbleId",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "scalar",
-              "type": "String",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "locationId",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-        ],
-        "name": "User",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "String",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "createdAt",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "DateTime",
-            },
-          },
-          Object {
-            "args": Array [
+            "inputType": Array [
               Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "UserWhereInput",
-                  },
-                ],
-                "name": "where",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": true,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "UserOrderByInput",
-                  },
-                ],
-                "name": "orderBy",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "object",
-                    "type": "UserWhereUniqueInput",
-                  },
-                ],
-                "name": "cursor",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "scalar",
-                    "type": "Int",
-                  },
-                ],
-                "name": "take",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": false,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "scalar",
-                    "type": "Int",
-                  },
-                ],
-                "name": "skip",
-              },
-              Object {
-                "inputType": Array [
-                  Object {
-                    "isList": true,
-                    "isNullable": false,
-                    "isRequired": false,
-                    "kind": "enum",
-                    "type": "UserDistinctFieldEnum",
-                  },
-                ],
-                "name": "distinct",
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationUpdateOneRequiredWithoutUserInput",
               },
             ],
-            "name": "members",
-            "outputType": Object {
-              "isList": true,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "User",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "private",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Boolean",
-            },
+            "name": "location",
           },
         ],
-        "name": "Bubble",
+        "isOneOf": false,
+        "name": "UserUpdateWithoutBubbleDataInput",
       },
       Object {
         "fields": Array [
           Object {
-            "args": Array [],
-            "name": "count",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-        ],
-        "name": "AggregateBubble",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "locationId",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Float",
-            },
-          },
-        ],
-        "name": "UserAvgAggregateOutputType",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "locationId",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-        ],
-        "name": "UserSumAggregateOutputType",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "locationId",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-        ],
-        "name": "UserMinAggregateOutputType",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "locationId",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-        ],
-        "name": "UserMaxAggregateOutputType",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "count",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "avg",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "UserAvgAggregateOutputType",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "sum",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "UserSumAggregateOutputType",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "min",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "UserMinAggregateOutputType",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "max",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "UserMaxAggregateOutputType",
-            },
-          },
-        ],
-        "name": "AggregateUser",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
             "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Float",
-            },
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "firstName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "lastName",
           },
         ],
-        "name": "LocationAvgAggregateOutputType",
+        "isOneOf": false,
+        "name": "UserUpdateManyDataInput",
       },
       Object {
         "fields": Array [
           Object {
-            "args": Array [],
-            "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-        ],
-        "name": "LocationSumAggregateOutputType",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-        ],
-        "name": "LocationMinAggregateOutputType",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-        ],
-        "name": "LocationMaxAggregateOutputType",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "count",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "avg",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "LocationAvgAggregateOutputType",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "sum",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "LocationSumAggregateOutputType",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "min",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "LocationMinAggregateOutputType",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "max",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "LocationMaxAggregateOutputType",
-            },
-          },
-        ],
-        "name": "AggregateLocation",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Float",
-            },
-          },
-          Object {
-            "args": Array [],
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "FloatFieldUpdateOperationsInput",
+              },
+            ],
             "name": "rating",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Float",
-            },
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "EnumPostStatusFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "status",
           },
         ],
-        "name": "PostAvgAggregateOutputType",
+        "isOneOf": false,
+        "name": "PostUpdateWithoutAuthorsDataInput",
       },
       Object {
         "fields": Array [
           Object {
-            "args": Array [],
-            "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-          Object {
-            "args": Array [],
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "FloatFieldUpdateOperationsInput",
+              },
+            ],
             "name": "rating",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Float",
-            },
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "EnumPostStatusFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "status",
           },
         ],
-        "name": "PostSumAggregateOutputType",
+        "isOneOf": false,
+        "name": "PostUpdateManyDataInput",
       },
       Object {
         "fields": Array [
           Object {
-            "args": Array [],
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
             "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
           },
           Object {
-            "args": Array [],
-            "name": "rating",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Float",
-            },
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "firstName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "lastName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "PostUpdateManyWithoutAuthorsInput",
+              },
+            ],
+            "name": "posts",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleUpdateOneWithoutMembersInput",
+              },
+            ],
+            "name": "Bubble",
           },
         ],
-        "name": "PostMinAggregateOutputType",
+        "isOneOf": false,
+        "name": "UserUpdateWithoutLocationDataInput",
       },
       Object {
         "fields": Array [
           Object {
-            "args": Array [],
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
             "name": "id",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
           },
           Object {
-            "args": Array [],
-            "name": "rating",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Float",
-            },
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "firstName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "StringFieldUpdateOperationsInput",
+              },
+            ],
+            "name": "lastName",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "LocationUpdateOneRequiredWithoutUserInput",
+              },
+            ],
+            "name": "location",
+          },
+          Object {
+            "inputType": Array [
+              Object {
+                "isList": false,
+                "isNullable": false,
+                "isRequired": false,
+                "kind": "object",
+                "type": "BubbleUpdateOneWithoutMembersInput",
+              },
+            ],
+            "name": "Bubble",
           },
         ],
-        "name": "PostMaxAggregateOutputType",
+        "isOneOf": false,
+        "name": "UserUpdateWithoutPostsDataInput",
       },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "count",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "avg",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "PostAvgAggregateOutputType",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "sum",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "PostSumAggregateOutputType",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "min",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "PostMinAggregateOutputType",
-            },
-          },
-          Object {
-            "args": Array [],
-            "name": "max",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": false,
-              "kind": "object",
-              "type": "PostMaxAggregateOutputType",
-            },
-          },
-        ],
-        "name": "AggregatePost",
-      },
+    ],
+    "outputTypes": Array [
       Object {
         "fields": Array [
           Object {
@@ -8158,22 +7445,6 @@ Object {
           },
         ],
         "name": "Query",
-      },
-      Object {
-        "fields": Array [
-          Object {
-            "args": Array [],
-            "name": "count",
-            "outputType": Object {
-              "isList": false,
-              "isNullable": false,
-              "isRequired": true,
-              "kind": "scalar",
-              "type": "Int",
-            },
-          },
-        ],
-        "name": "BatchPayload",
       },
       Object {
         "fields": Array [
@@ -9019,6 +8290,986 @@ Object {
           },
         ],
         "name": "Mutation",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "String",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "createdAt",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "DateTime",
+            },
+          },
+          Object {
+            "args": Array [
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "UserWhereInput",
+                  },
+                ],
+                "name": "where",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": true,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "UserOrderByInput",
+                  },
+                ],
+                "name": "orderBy",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "UserWhereUniqueInput",
+                  },
+                ],
+                "name": "cursor",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "scalar",
+                    "type": "Int",
+                  },
+                ],
+                "name": "take",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "scalar",
+                    "type": "Int",
+                  },
+                ],
+                "name": "skip",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": true,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "enum",
+                    "type": "UserDistinctFieldEnum",
+                  },
+                ],
+                "name": "distinct",
+              },
+            ],
+            "name": "members",
+            "outputType": Object {
+              "isList": true,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "User",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "private",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Boolean",
+            },
+          },
+        ],
+        "name": "Bubble",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "count",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+        ],
+        "name": "AggregateBubble",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "String",
+            },
+          },
+          Object {
+            "args": Array [
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "PostWhereInput",
+                  },
+                ],
+                "name": "where",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": true,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "PostOrderByInput",
+                  },
+                ],
+                "name": "orderBy",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "PostWhereUniqueInput",
+                  },
+                ],
+                "name": "cursor",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "scalar",
+                    "type": "Int",
+                  },
+                ],
+                "name": "take",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "scalar",
+                    "type": "Int",
+                  },
+                ],
+                "name": "skip",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": true,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "enum",
+                    "type": "PostDistinctFieldEnum",
+                  },
+                ],
+                "name": "distinct",
+              },
+            ],
+            "name": "posts",
+            "outputType": Object {
+              "isList": true,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "Post",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "firstName",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "String",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "lastName",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "String",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "location",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "object",
+              "type": "Location",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "Bubble",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "Bubble",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "bubbleId",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "scalar",
+              "type": "String",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "locationId",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+        ],
+        "name": "User",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "count",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "avg",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "UserAvgAggregateOutputType",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "sum",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "UserSumAggregateOutputType",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "min",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "UserMinAggregateOutputType",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "max",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "UserMaxAggregateOutputType",
+            },
+          },
+        ],
+        "name": "AggregateUser",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "country",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "String",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "city",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "String",
+            },
+          },
+          Object {
+            "args": Array [
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "UserWhereInput",
+                  },
+                ],
+                "name": "where",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": true,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "UserOrderByInput",
+                  },
+                ],
+                "name": "orderBy",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "UserWhereUniqueInput",
+                  },
+                ],
+                "name": "cursor",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "scalar",
+                    "type": "Int",
+                  },
+                ],
+                "name": "take",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "scalar",
+                    "type": "Int",
+                  },
+                ],
+                "name": "skip",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": true,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "enum",
+                    "type": "UserDistinctFieldEnum",
+                  },
+                ],
+                "name": "distinct",
+              },
+            ],
+            "name": "User",
+            "outputType": Object {
+              "isList": true,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "User",
+            },
+          },
+        ],
+        "name": "Location",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "count",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "avg",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "LocationAvgAggregateOutputType",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "sum",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "LocationSumAggregateOutputType",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "min",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "LocationMinAggregateOutputType",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "max",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "LocationMaxAggregateOutputType",
+            },
+          },
+        ],
+        "name": "AggregateLocation",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+          Object {
+            "args": Array [
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "UserWhereInput",
+                  },
+                ],
+                "name": "where",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": true,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "UserOrderByInput",
+                  },
+                ],
+                "name": "orderBy",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "object",
+                    "type": "UserWhereUniqueInput",
+                  },
+                ],
+                "name": "cursor",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "scalar",
+                    "type": "Int",
+                  },
+                ],
+                "name": "take",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": false,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "scalar",
+                    "type": "Int",
+                  },
+                ],
+                "name": "skip",
+              },
+              Object {
+                "inputType": Array [
+                  Object {
+                    "isList": true,
+                    "isNullable": false,
+                    "isRequired": false,
+                    "kind": "enum",
+                    "type": "UserDistinctFieldEnum",
+                  },
+                ],
+                "name": "distinct",
+              },
+            ],
+            "name": "authors",
+            "outputType": Object {
+              "isList": true,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "User",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "rating",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Float",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "status",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "enum",
+              "type": "PostStatus",
+            },
+          },
+        ],
+        "name": "Post",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "count",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "avg",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "PostAvgAggregateOutputType",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "sum",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "PostSumAggregateOutputType",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "min",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "PostMinAggregateOutputType",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "max",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": false,
+              "kind": "object",
+              "type": "PostMaxAggregateOutputType",
+            },
+          },
+        ],
+        "name": "AggregatePost",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "count",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+        ],
+        "name": "BatchPayload",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "locationId",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Float",
+            },
+          },
+        ],
+        "name": "UserAvgAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "locationId",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+        ],
+        "name": "UserSumAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "locationId",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+        ],
+        "name": "UserMinAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "locationId",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+        ],
+        "name": "UserMaxAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Float",
+            },
+          },
+        ],
+        "name": "LocationAvgAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+        ],
+        "name": "LocationSumAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+        ],
+        "name": "LocationMinAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+        ],
+        "name": "LocationMaxAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Float",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "rating",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Float",
+            },
+          },
+        ],
+        "name": "PostAvgAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "rating",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Float",
+            },
+          },
+        ],
+        "name": "PostSumAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "rating",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Float",
+            },
+          },
+        ],
+        "name": "PostMinAggregateOutputType",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "args": Array [],
+            "name": "id",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Int",
+            },
+          },
+          Object {
+            "args": Array [],
+            "name": "rating",
+            "outputType": Object {
+              "isList": false,
+              "isNullable": false,
+              "isRequired": true,
+              "kind": "scalar",
+              "type": "Float",
+            },
+          },
+        ],
+        "name": "PostMaxAggregateOutputType",
       },
     ],
   },

--- a/tests/schema/schema/__snapshots__/naming.test.ts.snap
+++ b/tests/schema/schema/__snapshots__/naming.test.ts.snap
@@ -25,11 +25,11 @@ input ModelNameCreateInput {
 }
 
 input ModelNameUpdateInput {
-  name: String
+  name: StringFieldUpdateOperationsInput
 }
 
 input ModelNameUpdateManyMutationInput {
-  name: String
+  name: StringFieldUpdateOperationsInput
 }
 
 input ModelNameWhereInput {
@@ -80,6 +80,10 @@ input NestedStringFilter {
 type Query {
   modelName(where: ModelNameWhereUniqueInput!): ModelName
   modelNames(first: Int, last: Int, before: ModelNameWhereUniqueInput, after: ModelNameWhereUniqueInput): [ModelName!]!
+}
+
+input StringFieldUpdateOperationsInput {
+  set: String
 }
 
 input StringFilter {

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,40 +775,40 @@
   resolved "https://registry.yarnpkg.com/@prisma/ci-info/-/ci-info-2.1.2.tgz#3da64f54584bde0aaf4b42f298a6c63f025aeb3f"
   integrity sha512-RhAHY+wp6Nqu89Tp3zfUVkpGfqk4TfngeOWaMGgmhP7mB2ASDtOl8dkwxHmI8eN4edo+luyjPmbJBC4kST321A==
 
-"@prisma/cli@^2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.6.0-dev.38.tgz#0382e358b00b6766cff32c12082d10885048c206"
-  integrity sha512-/L5z0b8AgPwjGbfAYhjMoGHrc1sq/PP9X5OW/S/VLe4xvJReps5hE1J0Ci+RFLq44x+PXJXAIwISlV/evkxBig==
+"@prisma/cli@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.6.0.tgz#13c0eb640af5c03d6295dcb75befcfcc5a297ff3"
+  integrity sha512-zZubTQNI4z2zoJxsjh4ob2FxqZEi7pEpCDHcgNyyX1kmLtDtwwneuW6hJjdJDjPc8oVSOryJIOuWxlLeMyMgUw==
 
-"@prisma/client@^2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.6.0-dev.38.tgz#d6ebe0a1cdb021c70ebf1ac4858a0902b3f6fba4"
-  integrity sha512-yW8Fdqmr2p497ceYxsvYXw8TKv2Tue12RDIYrqUc38UL2n4MfFI0OXWlaJkrYXCqCmaFT9yf+dRG5+9OBSIkiQ==
+"@prisma/client@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.6.0.tgz#8b9ab0dc39dfbd2e0253d0177e0f65053a542ad1"
+  integrity sha512-BxYBn8PQ7ACh6p6q9JJNlODV8i50aZA9f+HwPGtff9jhIuoyFdM0eh1Qldib1ngTzt1UnxvacqlpXDHlnL93Pg==
   dependencies:
     pkg-up "^3.1.0"
 
-"@prisma/debug@2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.6.0-dev.38.tgz#6619631dcad1ace4377c02aebc8c2642edb2a715"
-  integrity sha512-KtGsllZj39VcNYrqSJ6Pfd6ZxvZ2ERkRwFmBaKGV1Bg5o9SDAOB/L1tKzaJJFC4HFldQcGiA4MScXqwKiPMUcA==
+"@prisma/debug@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.6.0.tgz#7623862e310f7b30d64481643f693742ce562ee0"
+  integrity sha512-teEG9v44VU4Cblio1XfF2PTfK9xBE62R7RXdDXjQXNlZP0seG/Rh3dzXyePrHujRX100z1j9sD+cyoZTOMFVdQ==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/debug@2.6.0-dev.4":
-  version "2.6.0-dev.4"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.6.0-dev.4.tgz#8c5a69d93b7b5a2fd2f717be8985afeee30c091a"
-  integrity sha512-DyMZh9h1xI/0AFHJbKYzCDvhxayDDaBc1sQdvtERZ9d1nCQvgBy40fQyu5GDRIjwHKRa40CEpSKFZFbXQTRFvg==
+"@prisma/debug@2.6.0-dev.54":
+  version "2.6.0-dev.54"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.6.0-dev.54.tgz#79b62ed1c258f281704577216af543feaf5a0892"
+  integrity sha512-IKGBRY0gwIZ7zKAkNYqbo/zWmxqAYdAFF2z/lMH2S2xX4ogm7syySH0qOs+Nm3or46td6YAJtjd5oOeguyK70w==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/engine-core@2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.6.0-dev.38.tgz#dd0e033a26cf65c813f1c2e4b028298e7a4c6987"
-  integrity sha512-GzNK3cb15UHqC7WlJ+EhS6QufS89Q+ShOZOtdSmG2gG8xJZfL/xkawkrtYgDoC3JS9VHd8tjopRIWT/URW0vrA==
+"@prisma/engine-core@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.6.0.tgz#0806fda90b4be7070ed5e3ffefd48b668a976a72"
+  integrity sha512-pHFqIHVDfCSHnz3ixfEGJgqsU7qB/Yj9i637PGigPX2kKbWFHfYWojX0NKTZap95/gnp1jdkflYFaHCwFDwnSA==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.38"
-    "@prisma/generator-helper" "2.6.0-dev.38"
-    "@prisma/get-platform" "2.6.0-dev.38"
+    "@prisma/debug" "2.6.0"
+    "@prisma/generator-helper" "2.6.0"
+    "@prisma/get-platform" "2.6.0"
     chalk "^4.0.0"
     cross-fetch "^3.0.4"
     execa "^4.0.2"
@@ -817,16 +817,16 @@
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "git://github.com/mcollina/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
+    undici "git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
 
-"@prisma/engine-core@2.6.0-dev.4":
-  version "2.6.0-dev.4"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.6.0-dev.4.tgz#d73a11a8716ce506ea89be00d2c65a36bdfc774a"
-  integrity sha512-mtPG96T6fzJ9+sFMmUQJ0MULQn0k5PBAOkcFtkeaCZefMqYLve4hyyT/scXrP+qcEYVrSmK5uyR/rjeVmb+1jA==
+"@prisma/engine-core@2.6.0-dev.54":
+  version "2.6.0-dev.54"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.6.0-dev.54.tgz#2c5b001d1d0e67aaea43284f4c3179db035b6b80"
+  integrity sha512-kwTRBLL62fEdeEKAE2g0tRXNuat5SvKWKCrB5R/ozv0FkH9kSYewAq92dPybSZtLmHmTFddYkWRAEMc+TNiNAg==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.4"
-    "@prisma/generator-helper" "2.6.0-dev.4"
-    "@prisma/get-platform" "2.6.0-dev.4"
+    "@prisma/debug" "2.6.0-dev.54"
+    "@prisma/generator-helper" "2.6.0-dev.54"
+    "@prisma/get-platform" "2.6.0-dev.54"
     chalk "^4.0.0"
     cross-fetch "^3.0.4"
     execa "^4.0.2"
@@ -835,15 +835,15 @@
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "git://github.com/mcollina/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
+    undici "git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
 
-"@prisma/fetch-engine@2.6.0-dev.38", "@prisma/fetch-engine@^2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.6.0-dev.38.tgz#68262a7cce8bfcc137723a5b4a100cd569780b2c"
-  integrity sha512-E7xQfgOJMTF3TaUvX8OAztiYeCb4pCQqxa5Pdit/E/BSkhD7F7pqbfdMr/3zFMepygbpv164pzVSuxuYcfai4g==
+"@prisma/fetch-engine@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.6.0.tgz#f99dfe150fc82bcf498dec4a2a455112d9b05892"
+  integrity sha512-XohlBgJcMj7RWqXQiYAex8qwX7wiEpAS95aSmBiKDhZPnLeI8uOVKetIY7T676Jlsh+uDWtC75haP7V9MuNsHQ==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.38"
-    "@prisma/get-platform" "2.6.0-dev.38"
+    "@prisma/debug" "2.6.0"
+    "@prisma/get-platform" "2.6.0"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -861,13 +861,13 @@
     temp-dir "^2.0.0"
     tempy "^0.6.0"
 
-"@prisma/fetch-engine@2.6.0-dev.4":
-  version "2.6.0-dev.4"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.6.0-dev.4.tgz#f9d689d3e11d603fd2bb3712e69d65f3ab51ff0b"
-  integrity sha512-zS4exHymPx/ID5I6aFmE6hdlW1psZ9eyvafFj3pPhHuWRct0CSKolrIJfWpdaaZRSlC46XoUQT9FeXLNa7CSRg==
+"@prisma/fetch-engine@2.6.0-dev.54":
+  version "2.6.0-dev.54"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.6.0-dev.54.tgz#4032474fc646566fd5dc9f29f929d04a5babf495"
+  integrity sha512-Msa+OLGhka8P3BS6CoZ3PQmrHSwie4L1ytTivIklibJv5KFyUfXPRU/T4nBSrlM0cP6mZ/jyA4dP59TRELnRzg==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.4"
-    "@prisma/get-platform" "2.6.0-dev.4"
+    "@prisma/debug" "2.6.0-dev.54"
+    "@prisma/get-platform" "2.6.0-dev.54"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -885,46 +885,46 @@
     temp-dir "^2.0.0"
     tempy "^0.6.0"
 
-"@prisma/generator-helper@2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.6.0-dev.38.tgz#61fc58e7dfb30f851f863ca7351df35a1f9d896f"
-  integrity sha512-Gh50/3I5K22kTizeQioH0xbWNp1YnV+ogeALPspnVprJkiT8byLRSS2ZMNjXl8jkRRwv9hFZP0meIliOJDFMdg==
+"@prisma/generator-helper@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.6.0.tgz#9ab63445b9ef8c03acef5cd72c95944cfebf7696"
+  integrity sha512-YNCbqf15h0zP5SGAtkmyakkVqDZ6p7Qs6HXD256hqUki5QQJlQGcVsftJIYaVVJLntfRDHD4BnEEa/qwmn21Ng==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.38"
+    "@prisma/debug" "2.6.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/generator-helper@2.6.0-dev.4":
-  version "2.6.0-dev.4"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.6.0-dev.4.tgz#dbe4ce017cec624f3adc10ace7edc6b15f27d95e"
-  integrity sha512-tsnfGDyeybS1IE46u4IiKaJOkRmcr8jt7x64CQDRDa8dDz35m+kRAY3xzlU+BXkLfN2Bju71Zc0TLclx9mEHdQ==
+"@prisma/generator-helper@2.6.0-dev.54":
+  version "2.6.0-dev.54"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.6.0-dev.54.tgz#62bfffe489e3fd48b7fb504a10e3cbcd4e6cb3e5"
+  integrity sha512-s5/JS0PxmdEF/8RNLbfnFjYK/qBhfk/c4lsdAQH9vYw087VKOX0J26g0XhaT8s056R0A74Oov4LIMgcXNnLRog==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.4"
+    "@prisma/debug" "2.6.0-dev.54"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.6.0-dev.38", "@prisma/get-platform@^2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.6.0-dev.38.tgz#50116ef3126d203a25ba7652562a20e8d29e4ae7"
-  integrity sha512-N9t1mamXCfKarfr8c/a8+jNE59M/FXApIL+XSWWygHz+8iWEtWEzdVbcjA+djEugVXobm9GAtIzHIWH9rTCV7w==
+"@prisma/get-platform@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.6.0.tgz#a48c383d6c0d6ddfc184648ad54734642dfd41cd"
+  integrity sha512-oQckX7SMKmtkhLPtiZUfHJEFtd8mznifv2wb7mCRtit1DtYyfIjWZkXLVhK1/P0ocfANA8dtLvbaht619nYNHQ==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.38"
+    "@prisma/debug" "2.6.0"
 
-"@prisma/get-platform@2.6.0-dev.4":
-  version "2.6.0-dev.4"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.6.0-dev.4.tgz#dda0b6be6b05ad862370a5d254286e45fcf3930d"
-  integrity sha512-KZFH0fTyZwSVuBebvPfSAX4n8EdG1VpdZyRIvia+SQkp5IW+lsShJ8B9PB3I7Uq6cTUQJ/G5D6GUmn+ZVvDIGg==
+"@prisma/get-platform@2.6.0-dev.54":
+  version "2.6.0-dev.54"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.6.0-dev.54.tgz#f75ee036a7cee1f4dee4c8086f0c981678eda3ba"
+  integrity sha512-TkpARHQ6kciuZGHLeCWW+M75JBQ7o+enKRFOtZsL2X1XNnVswnMOqjUcGcWJwIIoBYH4UPC78C7QmoAxR/XFbg==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.4"
+    "@prisma/debug" "2.6.0-dev.54"
 
-"@prisma/ink-components@2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/ink-components/-/ink-components-2.6.0-dev.38.tgz#ef57729f5326f751a85f0fe275b2a9b6997a4163"
-  integrity sha512-sM/9DMg7QMtFuG9nKMB4Rbb1A0T2DjqPQw3ICnC3hAZbz8+OsDNx8UtKXxZh8Bx6Sh889opFQJUJhgMWAUn4Cw==
+"@prisma/ink-components@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/ink-components/-/ink-components-2.6.0.tgz#9ccc06f5c251ab7c0ace64ae09406406dc13ad47"
+  integrity sha512-EFSg06vKzYqxJBPFypDIvBPxIBkOPIo4JXaZj00f7r/qBwT4/ZBZbGzRzT54u83zNDOwD9wZUiHupKQt4JzbPA==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.38"
+    "@prisma/debug" "2.6.0"
     chalk "^4.0.0"
     cli-truncate "2.1.0"
     figures "^3.2.0"
@@ -932,17 +932,17 @@
     string-width "^4.2.0"
     terminal-link "^2.1.1"
 
-"@prisma/migrate@^2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/migrate/-/migrate-2.6.0-dev.38.tgz#5a213de56a976f0fb2c3fd4549665e12bd568f08"
-  integrity sha512-8lsin0x3o8tmpy7VVEHkFPjFD7bZPoZD+eN3YwRXt2AfPT2d76PI/Vf7XMZ+7j4y6FRlnvDHfB5g0sdG6nHpbA==
+"@prisma/migrate@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/migrate/-/migrate-2.6.0.tgz#6201b0f93afcd72ee6ccbffe08abb349d7eae5be"
+  integrity sha512-YBhuq/hOvj1zW8/nNBziXmeR461YR1aSMhaUPYzjJjKHck1HYV6KPndYf4S2UtkeDT/hLsOGAIN0j3jHM0fh0Q==
   dependencies:
-    "@prisma/debug" "2.6.0-dev.38"
-    "@prisma/fetch-engine" "2.6.0-dev.38"
-    "@prisma/get-platform" "2.6.0-dev.38"
-    "@prisma/ink-components" "2.6.0-dev.38"
-    "@prisma/studio-server" "0.268.0"
-    "@prisma/studio-types" "0.268.0"
+    "@prisma/debug" "2.6.0"
+    "@prisma/fetch-engine" "2.6.0"
+    "@prisma/get-platform" "2.6.0"
+    "@prisma/ink-components" "2.6.0"
+    "@prisma/studio-server" "0.272.0"
+    "@prisma/studio-types" "0.272.0"
     ansi-escapes "^4.3.1"
     cli-cursor "3.1.0"
     dashify "2.0.0"
@@ -969,17 +969,54 @@
     strip-ansi "^6.0.0"
     strip-indent "^3.0.0"
 
-"@prisma/sdk@2.6.0-dev.4":
-  version "2.6.0-dev.4"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.6.0-dev.4.tgz#5771e4d6e618b5127cfae2ddebc4ffd07083de72"
-  integrity sha512-ixd3E2r0z+xGo0Nf29hX0erk33WhgItc5suX5dli04TGbE0LI+1daepo8vHvKyZsjJiB5xFo7OSOj2kiAHRrzg==
+"@prisma/sdk@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.6.0.tgz#f67d589e71476f5667ece3891cddbf36de389730"
+  integrity sha512-zrunCZfPOBQXM+QqTsZpoXQGlrcA1M8vqvjzkCnddcNKQ8w7hU9u/YW4Eegk/sF9Q5bUDw1yOqLlXrHgNwcDLw==
   dependencies:
     "@apexearth/copy" "^1.4.5"
-    "@prisma/debug" "2.6.0-dev.4"
-    "@prisma/engine-core" "2.6.0-dev.4"
-    "@prisma/fetch-engine" "2.6.0-dev.4"
-    "@prisma/generator-helper" "2.6.0-dev.4"
-    "@prisma/get-platform" "2.6.0-dev.4"
+    "@prisma/debug" "2.6.0"
+    "@prisma/engine-core" "2.6.0"
+    "@prisma/fetch-engine" "2.6.0"
+    "@prisma/generator-helper" "2.6.0"
+    "@prisma/get-platform" "2.6.0"
+    archiver "^4.0.0"
+    arg "^4.1.3"
+    chalk "4.1.0"
+    checkpoint-client "1.1.11"
+    cli-truncate "^2.1.0"
+    execa "^4.0.0"
+    global-dirs "^2.0.1"
+    globby "^11.0.0"
+    has-yarn "^2.1.0"
+    make-dir "^3.0.2"
+    node-fetch "2.6.0"
+    p-map "^4.0.0"
+    read-pkg-up "^7.0.1"
+    resolve-pkg "^2.0.0"
+    rimraf "^3.0.2"
+    string-width "^4.2.0"
+    strip-ansi "6.0.0"
+    strip-indent "3.0.0"
+    tar "^6.0.1"
+    temp-dir "^2.0.0"
+    temp-write "^4.0.0"
+    tempy "^0.6.0"
+    terminal-link "^2.1.1"
+    tmp "0.2.1"
+    url-parse "^1.4.7"
+
+"@prisma/sdk@2.6.0-dev.54":
+  version "2.6.0-dev.54"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.6.0-dev.54.tgz#afeb5c3d6d96ae4c518965e9754051e59787421c"
+  integrity sha512-d/Mp1x3HiLbm8qkc5DXzghGLitGkxN/6uGb81EtxEYMvNe9BqcyD3BjdfTDEJX29LHilqMcVN842HK5Tav7Grw==
+  dependencies:
+    "@apexearth/copy" "^1.4.5"
+    "@prisma/debug" "2.6.0-dev.54"
+    "@prisma/engine-core" "2.6.0-dev.54"
+    "@prisma/fetch-engine" "2.6.0-dev.54"
+    "@prisma/generator-helper" "2.6.0-dev.54"
+    "@prisma/get-platform" "2.6.0-dev.54"
     archiver "^4.0.0"
     arg "^4.1.3"
     chalk "4.1.0"
@@ -1006,75 +1043,38 @@
     tmp "0.2.1"
     url-parse "^1.4.7"
 
-"@prisma/sdk@^2.6.0-dev.38":
-  version "2.6.0-dev.38"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.6.0-dev.38.tgz#9701758f153397a461d34d8ccd3059db9f48483d"
-  integrity sha512-nBzwWczD3489dzEnOVPvxMjLohzv/Ru79MFo1Nd2ollzTU0lMGCx2KkC0BLWhm685XGkcMOQVZDAwwFO9ZxKrQ==
+"@prisma/studio-server@0.272.0":
+  version "0.272.0"
+  resolved "https://registry.yarnpkg.com/@prisma/studio-server/-/studio-server-0.272.0.tgz#3a9c9dc974c47c90a8f2d89c09813a9dcdf4f10e"
+  integrity sha512-NNbgejzqWHVNRtoo0eK1/vd4FNnnTpmPBvesmvCdvu4Q54mZOO2gCtwGiMoKrkY9v/DV+aKizH8HADDxXR8jRw==
   dependencies:
-    "@apexearth/copy" "^1.4.5"
-    "@prisma/debug" "2.6.0-dev.38"
-    "@prisma/engine-core" "2.6.0-dev.38"
-    "@prisma/fetch-engine" "2.6.0-dev.38"
-    "@prisma/generator-helper" "2.6.0-dev.38"
-    "@prisma/get-platform" "2.6.0-dev.38"
-    archiver "^4.0.0"
-    arg "^4.1.3"
-    chalk "4.1.0"
-    checkpoint-client "1.1.10"
-    cli-truncate "^2.1.0"
-    execa "^4.0.0"
-    global-dirs "^2.0.1"
-    globby "^11.0.0"
-    has-yarn "^2.1.0"
-    make-dir "^3.0.2"
-    node-fetch "2.6.0"
-    p-map "^4.0.0"
-    read-pkg-up "^7.0.1"
-    resolve-pkg "^2.0.0"
-    rimraf "^3.0.2"
-    string-width "^4.2.0"
-    strip-ansi "6.0.0"
-    strip-indent "3.0.0"
-    tar "^6.0.1"
-    temp-dir "^2.0.0"
-    temp-write "^4.0.0"
-    tempy "^0.6.0"
-    terminal-link "^2.1.1"
-    tmp "0.2.1"
-    url-parse "^1.4.7"
-
-"@prisma/studio-server@0.268.0":
-  version "0.268.0"
-  resolved "https://registry.yarnpkg.com/@prisma/studio-server/-/studio-server-0.268.0.tgz#aaf83d78b57435f43dfe42f7b223ed4390d6a84b"
-  integrity sha512-mJlz6kUvNkUcoez8ySX22KUTpIg2iR5xc1gSx2qyi6M7s63qB9GjJNL3Pn/Eyba8SUTzwDNCr4sXeqRRp7G+PQ==
-  dependencies:
-    "@prisma/get-platform" "2.6.0-dev.4"
-    "@prisma/sdk" "2.6.0-dev.4"
-    "@prisma/studio" "0.268.0"
-    "@prisma/studio-transports" "0.268.0"
-    "@prisma/studio-types" "0.268.0"
+    "@prisma/get-platform" "2.6.0-dev.54"
+    "@prisma/sdk" "2.6.0-dev.54"
+    "@prisma/studio" "0.272.0"
+    "@prisma/studio-transports" "0.272.0"
+    "@prisma/studio-types" "0.272.0"
     "@sentry/node" "5.15.5"
     express "4.17.1"
     express-ws "4.0.0"
 
-"@prisma/studio-transports@0.268.0":
-  version "0.268.0"
-  resolved "https://registry.yarnpkg.com/@prisma/studio-transports/-/studio-transports-0.268.0.tgz#1aef51957d09c8ab85547357709172b330fb13d2"
-  integrity sha512-VVhTQ01vXHv+36g0hc0TefEziiMkYj1OkeD/i76kO/bQDfgvPfFBT/V+XWXRFtbd//fhjGhvPNsoZf6jRZcZHw==
+"@prisma/studio-transports@0.272.0":
+  version "0.272.0"
+  resolved "https://registry.yarnpkg.com/@prisma/studio-transports/-/studio-transports-0.272.0.tgz#3bccc16a43a3b9adaae873079e0e98bcf5a5819f"
+  integrity sha512-duBiSF6AU37x4tfT9n2p81+t4VlAmeXzr20O+g5P0nas1Z1GlBLv8U5zT8zwkVqOimj9c3gLd6kRDdU6VYfhEQ==
   dependencies:
-    "@prisma/sdk" "2.6.0-dev.4"
-    "@prisma/studio-types" "0.268.0"
+    "@prisma/sdk" "2.6.0-dev.54"
+    "@prisma/studio-types" "0.272.0"
     "@sentry/node" "5.15.5"
 
-"@prisma/studio-types@0.268.0":
-  version "0.268.0"
-  resolved "https://registry.yarnpkg.com/@prisma/studio-types/-/studio-types-0.268.0.tgz#83e1129b4d7e550a25733e83c5dbbd630b9a364e"
-  integrity sha512-x7MP1nuhNOl9pQqEza6UYvBQkKgD7gd4w3oU2usnkSQK0ghFOgqnlVkFsbOgs1+9rPSHMckxYyrrhUpuRMRwbg==
+"@prisma/studio-types@0.272.0":
+  version "0.272.0"
+  resolved "https://registry.yarnpkg.com/@prisma/studio-types/-/studio-types-0.272.0.tgz#c27574a7cc117cfadc8b1ec32b3ee83592e50b64"
+  integrity sha512-3L05IemiF3jBGQ6xoA+UGoVaD/UAsJZ0aZ2pHbiG6gYhF0d+3EF1aXbe99Jkh1jLHW4kygsdjmu+8XrGcVlbCg==
 
-"@prisma/studio@0.268.0":
-  version "0.268.0"
-  resolved "https://registry.yarnpkg.com/@prisma/studio/-/studio-0.268.0.tgz#9941c1127cbf8a08e2477029b7767167fabef697"
-  integrity sha512-cPV8tMiRj0QlJwE9C3zCHnTj3ZgkcZz+Z9/iq5XLrzW8ezc7SHMOVVkIWWj8Zqbr0emmrd/PiJ4AtzQx4kPAcg==
+"@prisma/studio@0.272.0":
+  version "0.272.0"
+  resolved "https://registry.yarnpkg.com/@prisma/studio/-/studio-0.272.0.tgz#fc33cde265949215d4459f00370e5c0cd37387c6"
+  integrity sha512-5UCDY55SkcUx6IY1IH1EEL90sMvj6vTuAwU5tV9It7K0ZP8u4Y+5vVs0w4V1C2Bjc/vcu6RrIhFf0Vj+6MJcBw==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -2572,6 +2572,20 @@ checkpoint-client@1.1.10:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.10.tgz#af8d01ea30c0a0d84d100012cb9a5a1a2ce5266d"
   integrity sha512-HERlC3DqsaaxDlWfhE7zq2bp4cWIxccwJAB1XXtzxYzbagfDt79NQZv6X3dJTS9iKusj+qvOVSsl1FxI/gqrOQ==
+  dependencies:
+    "@prisma/ci-info" "2.1.2"
+    cross-spawn "7.0.3"
+    env-paths "2.2.0"
+    fast-write-atomic "0.2.1"
+    make-dir "3.1.0"
+    ms "2.1.2"
+    node-fetch "2.6.0"
+    uuid "8.1.0"
+
+checkpoint-client@1.1.11:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.11.tgz#992818640b9ef12d66304bf973d993760b1e6926"
+  integrity sha512-p+eDmbuKlP6oHgknetUoqWTHnQsWfSbDlaMlKgwNh8RiEdLQVZ5z1rcU4+0iBynZe2z8sJHHSdWo9VQTmGWRLw==
   dependencies:
     "@prisma/ci-info" "2.1.2"
     cross-spawn "7.0.3"
@@ -7701,9 +7715,9 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-"undici@git://github.com/mcollina/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744":
+"undici@git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744":
   version "1.3.1"
-  resolved "git://github.com/mcollina/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
+  resolved "git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
BREAKING CHANGE:

The schema contribution for update of fields of type `Float` and `Int` has changed. This reflects the new `atomicNumberOperations` preview feature of [Prisma 2.6](https://github.com/prisma/prisma/releases/tag/2.6.0).

For example;

Before:

```gql
FooUpdateManyMutationInput {
  bar: Float
}
```

After:

```gql
FooUpdateManyMutationInput {
  bar: FloatFieldUpdateOperationsInput
}

# Only one operation can be done per field at a time.
input FloatFieldUpdateOperationsInput {
  set: Float
  # These fields only appear if "atomicNumberOperations" prisma client preview feature is enabled
  increment: Float
  decrement: Float
  multiply: Float
  divide: Float
}
```