### PR TITLE
fix: handle json types when converting nulls to undefined

### DIFF
--- a/src/null.ts
+++ b/src/null.ts
@@ -30,7 +30,7 @@ export function transformNullsToUndefined(
 
     if (shouldConvertNullToUndefined) {
       graphqlArgs[key] = undefined
-    } else if (Lo.isPlainObject(val)) {
+    } else if (Lo.isPlainObject(val) && prismaArg.inputType.type != 'Json') {
       const nestedPrismaArgs = dmmf.getInputTypeWithIndexedFields(prismaArg.inputType.type).fields
 
       graphqlArgs[key] = transformNullsToUndefined(graphqlArgs[key], nestedPrismaArgs, dmmf)
@@ -39,4 +39,3 @@ export function transformNullsToUndefined(
 
   return graphqlArgs
 }
-


### PR DESCRIPTION
`Json` type is not properly handled when converting nulls to undefined.

fixes #797 