### PR TITLE
fix: missing typegen file in module #875

### DIFF
--- a/src/typegen/render.ts
+++ b/src/typegen/render.ts
@@ -52,7 +52,7 @@ export function render(params: {
   paginationStrategy: PaginationStrategy
 }) {
   return `\
-import * as Typegen from '${params.nexusPrismaImportId ?? 'nexus-plugin-prisma/typegen'}'
+import * as Typegen from '${params.nexusPrismaImportId ?? 'nexus-plugin-prisma/dist/typegen/static'}'
 import * as Prisma from '${params.prismaClientImportId}';
 
 // Pagination type

--- a/tests/schema/__snapshots__/computedInputs.test.ts.snap
+++ b/tests/schema/__snapshots__/computedInputs.test.ts.snap
@@ -60,7 +60,7 @@ input UserWhereUniqueInput {
   id: Int
 }
 ",
-  "typegen": "import * as Typegen from 'nexus-plugin-prisma/typegen'
+  "typegen": "import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type
@@ -193,7 +193,7 @@ input UserWhereUniqueInput {
   id: Int
 }
 ",
-  "typegen": "import * as Typegen from 'nexus-plugin-prisma/typegen'
+  "typegen": "import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type

--- a/tests/schema/__snapshots__/crud.test.ts.snap
+++ b/tests/schema/__snapshots__/crud.test.ts.snap
@@ -12,7 +12,7 @@ type User {
 `;
 
 exports[`support models with only one id field (some crud operations are removed): typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type

--- a/tests/schema/__snapshots__/enums.test.ts.snap
+++ b/tests/schema/__snapshots__/enums.test.ts.snap
@@ -26,7 +26,7 @@ input UserWhereUniqueInput {
 `;
 
 exports[`does not automatically publish input/enum type if already created by user: typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type
@@ -158,7 +158,7 @@ input UserWhereUniqueInput {
 `;
 
 exports[`does not publish enum twice (from input/output type): typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type
@@ -256,7 +256,7 @@ type User {
 `;
 
 exports[`publishes enum even as output type: typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type

--- a/tests/schema/__snapshots__/filtering-ordering.test.ts.snap
+++ b/tests/schema/__snapshots__/filtering-ordering.test.ts.snap
@@ -25,7 +25,7 @@ input UserWhereUniqueInput {
 `;
 
 exports[`in dev stage, removes filtering or ordering entirely if no arg or wrong args are passed and log error: typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type

--- a/tests/schema/__snapshots__/naming.test.ts.snap
+++ b/tests/schema/__snapshots__/naming.test.ts.snap
@@ -103,7 +103,7 @@ input StringFilter {
 `;
 
 exports[`generates publishers pluralized & camel-cased: typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type

--- a/tests/schema/__snapshots__/ordering.test.ts.snap
+++ b/tests/schema/__snapshots__/ordering.test.ts.snap
@@ -25,7 +25,7 @@ enum SortOrder {
 `;
 
 exports[`orderby fields can be allow-listed: typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type

--- a/tests/schema/__snapshots__/outputs.test.ts.snap
+++ b/tests/schema/__snapshots__/outputs.test.ts.snap
@@ -70,7 +70,7 @@ input UserWhereUniqueInput {
 `;
 
 exports[`publishes scalars from input types: typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type

--- a/tests/schema/__snapshots__/pagination.test.ts.snap
+++ b/tests/schema/__snapshots__/pagination.test.ts.snap
@@ -22,7 +22,7 @@ type User {
 `;
 
 exports[`support prisma pagination: typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type
@@ -148,7 +148,7 @@ type User {
 `;
 
 exports[`support relay pagination (default): typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type

--- a/tests/schema/__snapshots__/scalars.test.ts.snap
+++ b/tests/schema/__snapshots__/scalars.test.ts.snap
@@ -19,7 +19,7 @@ type User {
 `;
 
 exports[`publishes date and json scalar output types: typegen 1`] = `
-"import * as Typegen from 'nexus-plugin-prisma/typegen'
+"import * as Typegen from 'nexus-plugin-prisma/dist/typegen/static'
 import * as Prisma from '@prisma/client';
 
 // Pagination type


### PR DESCRIPTION
I'm trying to address #875 but I'm having trouble building nexus-plugin-prisma on its own (i.e. outside my project where it's linked).

Is the problem with the generated typegen path more complex than adjusting nexus-plugin-prisma/src/typegen/render.ts ?