### PR TITLE
feat: add disableAtomicOperations option

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -158,11 +158,16 @@ export interface Options {
   scalars?: Partial<Record<Typegen.GetGen<'scalars', string>, GraphQLScalarType>>
   computedInputs?: GlobalComputedInputs
   /**
-   * Graphql does not support union types, atomic operation are enabled by default for CRUD update and upsert
+   * Enable atomic operations
    *
-   * @default false
+   * @remarks
+   *
+   * GraphQL doesn't support union types. The plugin has to apply a flattening heuristic and pick by default the broadest member of the union.
+   * On update and upsert, the broadest member is the atomic operation, which is not ideal in many cases.
+   *
+   * @default true
    */
-  disableAtomicOperations?: boolean
+  atomicOperations?: boolean
 }
 
 export interface InternalOptions extends Options {
@@ -262,7 +267,7 @@ export class SchemaBuilder {
       getTransformedDmmf(config.inputs.prismaClient, {
         globallyComputedInputs: this.globallyComputedInputs,
         paginationStrategy: this.paginationStrategy,
-        disableAtomicOperations: config.disableAtomicOperations,
+        atomicOperations: config.atomicOperations,
       })
     this.scalars = (options.scalars as any) ?? {}
     this.publisher = new Publisher(this.dmmf, config.nexusBuilder, this.scalars)

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -226,6 +226,7 @@ const defaultOptions = {
   shouldGenerateArtifacts,
   prismaClient: (ctx: any) => ctx.prisma,
   paginationStrategy: 'relay' as const,
+  atomicOperations: true,
   inputs: {
     prismaClient: defaultClientPath,
   },

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -162,7 +162,7 @@ export interface Options {
    *
    * @remarks
    *
-   * GraphQL doesn't support union types. The plugin has to apply a flattening heuristic and pick by default the broadest member of the union.
+   * GraphQL [doesn't support union input types](https://github.com/graphql/graphql-spec/pull/733). But Prisma Client atomic operations (e.g. [atomic operations on update for Int and Float fields](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/crud#atomic-operations-on-update)) are modelled as a union input type in TypeScript. By default Nexus Prisma will model this as a nested input object type with runtime validation that only one operation is sent by the client. However, you can configure this. If your API clients do not need the power of all the atomic operations then disable them. When disabled the nested input object is replaced by only one of the possible atomic operations. Disabling removes types from your API schema and thus complexity for your clients.
    * On update and upsert, the broadest member is the atomic operation, which is not ideal in many cases.
    *
    * @default true

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -163,7 +163,6 @@ export interface Options {
    * @remarks
    *
    * GraphQL [doesn't support union input types](https://github.com/graphql/graphql-spec/pull/733). But Prisma Client atomic operations (e.g. [atomic operations on update for Int and Float fields](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/crud#atomic-operations-on-update)) are modelled as a union input type in TypeScript. By default Nexus Prisma will model this as a nested input object type with runtime validation that only one operation is sent by the client. However, you can configure this. If your API clients do not need the power of all the atomic operations then disable them. When disabled the nested input object is replaced by only one of the possible atomic operations. Disabling removes types from your API schema and thus complexity for your clients.
-   * On update and upsert, the broadest member is the atomic operation, which is not ideal in many cases.
    *
    * @default true
    */

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -157,6 +157,12 @@ export interface Options {
    */
   scalars?: Partial<Record<Typegen.GetGen<'scalars', string>, GraphQLScalarType>>
   computedInputs?: GlobalComputedInputs
+  /**
+   * Graphql does not support union types, atomic operation are enabled by default for CRUD update and upsert
+   *
+   * @default false
+   */
+  disableAtomicOperations?: boolean
 }
 
 export interface InternalOptions extends Options {
@@ -256,6 +262,7 @@ export class SchemaBuilder {
       getTransformedDmmf(config.inputs.prismaClient, {
         globallyComputedInputs: this.globallyComputedInputs,
         paginationStrategy: this.paginationStrategy,
+        disableAtomicOperations: config.disableAtomicOperations,
       })
     this.scalars = (options.scalars as any) ?? {}
     this.publisher = new Publisher(this.dmmf, config.nexusBuilder, this.scalars)

--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -119,9 +119,10 @@ function flattenUnionOfSchemaArg(
   atomicOperations: boolean
 ): DMMF.SchemaArgInputType {
   // Remove atomic operations if needed
-  const filteredInputTypes = atomicOperations
-    ? inputTypes
-    : inputTypes.filter((a) => !getReturnTypeName(a.type).endsWith('OperationsInput'))
+  const filteredInputTypes =
+    atomicOperations === false
+      ? inputTypes.filter((a) => !getReturnTypeName(a.type).endsWith('OperationsInput'))
+      : inputTypes
 
   return (
     // We're intentionally ignoring the `<Model>RelationFilter` member of some union type for now and using the `<Model>WhereInput` instead to avoid making a breaking change

--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -118,10 +118,10 @@ function transformArg(arg: DMMF.SchemaArg, disableAtomicOperations: boolean): Dm
  */
 function flattenUnionOfSchemaArg(
   inputTypes: DMMF.SchemaArgInputType[],
-  removeAtomicOperations: boolean
+  disableAtomicOperations: boolean
 ): DMMF.SchemaArgInputType {
   // Remove atomic operations if needed
-  const filteredInputTypes = removeAtomicOperations
+  const filteredInputTypes = disableAtomicOperations
     ? inputTypes.filter((a) => !getReturnTypeName(a.type).endsWith('OperationsInput'))
     : inputTypes
 
@@ -236,7 +236,7 @@ export async function addComputedInputs({
 function transformInputType(
   inputType: DMMF.InputType,
   globallyComputedInputs: GlobalComputedInputs,
-  removeAtomicOperations: boolean
+  disableAtomicOperations: boolean
 ): DmmfTypes.InputType {
   const fieldNames = inputType.fields.map((field) => field.name)
   /**
@@ -255,7 +255,7 @@ function transformInputType(
     ...inputType,
     fields: inputType.fields
       .filter((field) => !(field.name in globallyComputedInputs))
-      .map((_) => transformArg(_, removeAtomicOperations)),
+      .map((_) => transformArg(_, disableAtomicOperations)),
     computedInputs: globallyComputedInputsInType,
   }
 }

--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -6,6 +6,7 @@ import { DmmfTypes } from './DmmfTypes'
 import { getPrismaClientDmmf } from './utils'
 
 export type TransformOptions = {
+  disableAtomicOperations?: boolean
   globallyComputedInputs?: GlobalComputedInputs
   paginationStrategy?: PaginationStrategy
 }
@@ -18,6 +19,7 @@ export const getTransformedDmmf = (
 const addDefaultOptions = (givenOptions?: TransformOptions): Required<TransformOptions> => ({
   globallyComputedInputs: {},
   paginationStrategy: paginationStrategies.relay,
+  disableAtomicOperations: false,
   ...givenOptions,
 })
 
@@ -46,16 +48,18 @@ const paginationArgNames = ['cursor', 'take', 'skip']
 
 function transformSchema(
   schema: DMMF.Schema,
-  { globallyComputedInputs, paginationStrategy }: Required<TransformOptions>
+  { globallyComputedInputs, paginationStrategy, disableAtomicOperations }: Required<TransformOptions>
 ): DmmfTypes.Schema {
   return {
     enums: schema.enums,
-    inputTypes: schema.inputTypes.map((_) => transformInputType(_, globallyComputedInputs)),
+    inputTypes: schema.inputTypes.map((_) =>
+      transformInputType(_, globallyComputedInputs, disableAtomicOperations)
+    ),
     outputTypes: schema.outputTypes.map((o) => {
       return {
         ...o,
         fields: o.fields.map((f) => {
-          let args = f.args.map(transformArg)
+          let args = f.args.map((_) => transformArg(_, disableAtomicOperations))
           const argNames = args.map((a) => a.name)
 
           // If this field has pagination
@@ -89,8 +93,8 @@ function transformSchema(
  * heuristics. A conversion is needed because GraphQL does not
  * support union types on args, but Prisma Client does.
  */
-function transformArg(arg: DMMF.SchemaArg): DmmfTypes.SchemaArg {
-  const inputType = flattenUnionOfSchemaArg(arg.inputTypes)
+function transformArg(arg: DMMF.SchemaArg, disableAtomicOperations: boolean): DmmfTypes.SchemaArg {
+  const inputType = flattenUnionOfSchemaArg(arg.inputTypes, disableAtomicOperations)
 
   return {
     name: arg.name,
@@ -112,18 +116,26 @@ function transformArg(arg: DMMF.SchemaArg): DmmfTypes.SchemaArg {
  *
  * Apart from some exceptions, we're generally trying to pick the broadest member type of the union.
  */
-function flattenUnionOfSchemaArg(inputTypes: DMMF.SchemaArgInputType[]): DMMF.SchemaArgInputType {
+function flattenUnionOfSchemaArg(
+  inputTypes: DMMF.SchemaArgInputType[],
+  removeAtomicOperations: boolean
+): DMMF.SchemaArgInputType {
+  // Remove atomic operations if needed
+  const filteredInputTypes = removeAtomicOperations
+    ? inputTypes.filter((a) => !getReturnTypeName(a.type).endsWith('OperationsInput'))
+    : inputTypes
+
   return (
     // We're intentionally ignoring the `<Model>RelationFilter` member of some union type for now and using the `<Model>WhereInput` instead to avoid making a breaking change
-    inputTypes.find(
+    filteredInputTypes.find(
       (a) => a.kind === 'object' && a.isList == true && getReturnTypeName(a.type).endsWith('WhereInput')
     ) ??
     // Same here
-    inputTypes.find((a) => a.kind === 'object' && getReturnTypeName(a.type).endsWith('WhereInput')) ??
+    filteredInputTypes.find((a) => a.kind === 'object' && getReturnTypeName(a.type).endsWith('WhereInput')) ??
     // [AnyType]
-    inputTypes.find((a) => a.kind === 'object' && a.isList === true) ??
+    filteredInputTypes.find((a) => a.kind === 'object' && a.isList === true) ??
     // AnyType
-    inputTypes.find((a) => a.kind === 'object') ??
+    filteredInputTypes.find((a) => a.kind === 'object') ??
     // fallback to the first member of the union
     inputTypes[0]
   )
@@ -223,7 +235,8 @@ export async function addComputedInputs({
 
 function transformInputType(
   inputType: DMMF.InputType,
-  globallyComputedInputs: GlobalComputedInputs
+  globallyComputedInputs: GlobalComputedInputs,
+  removeAtomicOperations: boolean
 ): DmmfTypes.InputType {
   const fieldNames = inputType.fields.map((field) => field.name)
   /**
@@ -240,7 +253,9 @@ function transformInputType(
   )
   return {
     ...inputType,
-    fields: inputType.fields.filter((field) => !(field.name in globallyComputedInputs)).map(transformArg),
+    fields: inputType.fields
+      .filter((field) => !(field.name in globallyComputedInputs))
+      .map((_) => transformArg(_, removeAtomicOperations)),
     computedInputs: globallyComputedInputsInType,
   }
 }

--- a/tests/schema/__snapshots__/atomicOperations.test.ts.snap
+++ b/tests/schema/__snapshots__/atomicOperations.test.ts.snap
@@ -1,0 +1,373 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`disable atomic operations: schema 1`] = `
+"type Mutation {
+  createOneModelName(data: ModelNameCreateInput!): ModelName!
+  deleteOneModelName(where: ModelNameWhereUniqueInput!): ModelName
+  updateOneModelName(data: ModelNameUpdateInput!, where: ModelNameWhereUniqueInput!): ModelName
+  upsertOneModelName(where: ModelNameWhereUniqueInput!, create: ModelNameCreateInput!, update: ModelNameUpdateInput!): ModelName!
+  updateManyModelName(data: ModelNameUpdateManyMutationInput!, where: ModelNameWhereInput): BatchPayload!
+}
+
+type ModelName {
+  id: Int!
+}
+
+input ModelNameCreateInput {
+  name: String!
+  amount: Int!
+}
+
+input ModelNameWhereUniqueInput {
+  id: Int
+}
+
+input ModelNameUpdateInput {
+  name: String
+  amount: Int
+}
+
+type BatchPayload {
+  count: Int!
+}
+
+input ModelNameUpdateManyMutationInput {
+  name: String
+  amount: Int
+}
+
+input ModelNameWhereInput {
+  AND: [ModelNameWhereInput!]
+  OR: [ModelNameWhereInput!]
+  NOT: [ModelNameWhereInput!]
+  id: IntFilter
+  name: StringFilter
+  amount: IntFilter
+}
+
+input IntFilter {
+  equals: Int
+  in: [Int!]
+  notIn: [Int!]
+  lt: Int
+  lte: Int
+  gt: Int
+  gte: Int
+  not: NestedIntFilter
+}
+
+input StringFilter {
+  equals: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  not: NestedStringFilter
+}
+
+input NestedIntFilter {
+  equals: Int
+  in: [Int!]
+  notIn: [Int!]
+  lt: Int
+  lte: Int
+  gt: Int
+  gte: Int
+  not: NestedIntFilter
+}
+
+input NestedStringFilter {
+  equals: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  not: NestedStringFilter
+}
+
+type Query {
+  ok: Boolean!
+}
+"
+`;
+
+exports[`disable atomic operations: typegen 1`] = `
+"import * as Typegen from 'nexus-plugin-prisma/typegen'
+import * as Prisma from '@prisma/client';
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  before?: boolean
+  after?: boolean
+}
+
+// Prisma custom scalar names
+type CustomScalars = 'No custom scalars are used in your Prisma Schema.'
+
+// Prisma model type definitions
+interface PrismaModels {
+  ModelName: Prisma.ModelName
+}
+
+// Prisma input types metadata
+interface NexusPrismaInputs {
+  Query: {
+    modelNames: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'name' | 'amount'
+      ordering: 'id' | 'name' | 'amount'
+    }
+  },
+  ModelName: {
+
+  }
+}
+
+// Prisma output types metadata
+interface NexusPrismaOutputs {
+  Query: {
+    modelName: 'ModelName'
+    modelNames: 'ModelName'
+  },
+  Mutation: {
+    createOneModelName: 'ModelName'
+    updateOneModelName: 'ModelName'
+    updateManyModelName: 'BatchPayload'
+    deleteOneModelName: 'ModelName'
+    deleteManyModelName: 'BatchPayload'
+    upsertOneModelName: 'ModelName'
+  },
+  ModelName: {
+    id: 'Int'
+    name: 'String'
+    amount: 'Int'
+  }
+}
+
+// Helper to gather all methods relative to a model
+interface NexusPrismaMethods {
+  ModelName: Typegen.NexusPrismaFields<'ModelName'>
+  Query: Typegen.NexusPrismaFields<'Query'>
+  Mutation: Typegen.NexusPrismaFields<'Mutation'>
+}
+
+interface NexusPrismaGenTypes {
+  inputs: NexusPrismaInputs
+  outputs: NexusPrismaOutputs
+  methods: NexusPrismaMethods
+  models: PrismaModels
+  pagination: Pagination
+  scalars: CustomScalars
+}
+
+declare global {
+  interface NexusPrismaGen extends NexusPrismaGenTypes {}
+
+  type NexusPrisma<
+    TypeName extends string,
+    ModelOrCrud extends 'model' | 'crud'
+  > = Typegen.GetNexusPrisma<TypeName, ModelOrCrud>;
+}
+  "
+`;
+
+exports[`support atomic operations (default): schema 1`] = `
+"type Mutation {
+  createOneModelName(data: ModelNameCreateInput!): ModelName!
+  deleteOneModelName(where: ModelNameWhereUniqueInput!): ModelName
+  updateOneModelName(data: ModelNameUpdateInput!, where: ModelNameWhereUniqueInput!): ModelName
+  upsertOneModelName(where: ModelNameWhereUniqueInput!, create: ModelNameCreateInput!, update: ModelNameUpdateInput!): ModelName!
+  updateManyModelName(data: ModelNameUpdateManyMutationInput!, where: ModelNameWhereInput): BatchPayload!
+}
+
+type ModelName {
+  id: Int!
+}
+
+input ModelNameCreateInput {
+  name: String!
+  amount: Int!
+}
+
+input ModelNameWhereUniqueInput {
+  id: Int
+}
+
+input ModelNameUpdateInput {
+  name: StringFieldUpdateOperationsInput
+  amount: IntFieldUpdateOperationsInput
+}
+
+type BatchPayload {
+  count: Int!
+}
+
+input ModelNameUpdateManyMutationInput {
+  name: StringFieldUpdateOperationsInput
+  amount: IntFieldUpdateOperationsInput
+}
+
+input ModelNameWhereInput {
+  AND: [ModelNameWhereInput!]
+  OR: [ModelNameWhereInput!]
+  NOT: [ModelNameWhereInput!]
+  id: IntFilter
+  name: StringFilter
+  amount: IntFilter
+}
+
+input StringFieldUpdateOperationsInput {
+  set: String
+}
+
+input IntFieldUpdateOperationsInput {
+  set: Int
+}
+
+input IntFilter {
+  equals: Int
+  in: [Int!]
+  notIn: [Int!]
+  lt: Int
+  lte: Int
+  gt: Int
+  gte: Int
+  not: NestedIntFilter
+}
+
+input StringFilter {
+  equals: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  not: NestedStringFilter
+}
+
+input NestedIntFilter {
+  equals: Int
+  in: [Int!]
+  notIn: [Int!]
+  lt: Int
+  lte: Int
+  gt: Int
+  gte: Int
+  not: NestedIntFilter
+}
+
+input NestedStringFilter {
+  equals: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  not: NestedStringFilter
+}
+
+type Query {
+  ok: Boolean!
+}
+"
+`;
+
+exports[`support atomic operations (default): typegen 1`] = `
+"import * as Typegen from 'nexus-plugin-prisma/typegen'
+import * as Prisma from '@prisma/client';
+
+// Pagination type
+type Pagination = {
+  first?: boolean
+  last?: boolean
+  before?: boolean
+  after?: boolean
+}
+
+// Prisma custom scalar names
+type CustomScalars = 'No custom scalars are used in your Prisma Schema.'
+
+// Prisma model type definitions
+interface PrismaModels {
+  ModelName: Prisma.ModelName
+}
+
+// Prisma input types metadata
+interface NexusPrismaInputs {
+  Query: {
+    modelNames: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'name' | 'amount'
+      ordering: 'id' | 'name' | 'amount'
+    }
+  },
+  ModelName: {
+
+  }
+}
+
+// Prisma output types metadata
+interface NexusPrismaOutputs {
+  Query: {
+    modelName: 'ModelName'
+    modelNames: 'ModelName'
+  },
+  Mutation: {
+    createOneModelName: 'ModelName'
+    updateOneModelName: 'ModelName'
+    updateManyModelName: 'BatchPayload'
+    deleteOneModelName: 'ModelName'
+    deleteManyModelName: 'BatchPayload'
+    upsertOneModelName: 'ModelName'
+  },
+  ModelName: {
+    id: 'Int'
+    name: 'String'
+    amount: 'Int'
+  }
+}
+
+// Helper to gather all methods relative to a model
+interface NexusPrismaMethods {
+  ModelName: Typegen.NexusPrismaFields<'ModelName'>
+  Query: Typegen.NexusPrismaFields<'Query'>
+  Mutation: Typegen.NexusPrismaFields<'Mutation'>
+}
+
+interface NexusPrismaGenTypes {
+  inputs: NexusPrismaInputs
+  outputs: NexusPrismaOutputs
+  methods: NexusPrismaMethods
+  models: PrismaModels
+  pagination: Pagination
+  scalars: CustomScalars
+}
+
+declare global {
+  interface NexusPrismaGen extends NexusPrismaGenTypes {}
+
+  type NexusPrisma<
+    TypeName extends string,
+    ModelOrCrud extends 'model' | 'crud'
+  > = Typegen.GetNexusPrisma<TypeName, ModelOrCrud>;
+}
+  "
+`;

--- a/tests/schema/__snapshots__/atomicOperations.test.ts.snap
+++ b/tests/schema/__snapshots__/atomicOperations.test.ts.snap
@@ -233,6 +233,10 @@ input StringFieldUpdateOperationsInput {
 
 input IntFieldUpdateOperationsInput {
   set: Int
+  increment: Int
+  decrement: Int
+  multiply: Int
+  divide: Int
 }
 
 input IntFilter {

--- a/tests/schema/atomicOperations.test.ts
+++ b/tests/schema/atomicOperations.test.ts
@@ -1,0 +1,69 @@
+import { objectType } from '@nexus/schema'
+import { paginationStrategies } from '../../src/pagination'
+import { generateSchemaAndTypes } from '../__utils'
+
+it('support atomic operations (default)', async () => {
+  const datamodel = `
+  model ModelName {
+    id      Int @id @default(autoincrement())
+    name    String
+    amount  Int
+  }
+`
+  const ModelName = objectType({
+    name: 'ModelName',
+    definition(t: any) {
+      t.model.id()
+    },
+  })
+
+  const Mutation = objectType({
+    name: 'Mutation',
+    definition(t: any) {
+      t.crud.createOneModelName()
+      t.crud.deleteOneModelName()
+      t.crud.updateOneModelName()
+      t.crud.upsertOneModelName()
+      t.crud.updateManyModelName()
+    },
+  })
+
+  const { schemaString: schema, typegen } = await generateSchemaAndTypes(datamodel, [Mutation, ModelName])
+
+  expect(schema).toMatchSnapshot('schema')
+  expect(typegen).toMatchSnapshot('typegen')
+})
+
+it('disable atomic operations', async () => {
+  const datamodel = `
+  model ModelName {
+    id      Int @id @default(autoincrement())
+    name    String
+    amount  Int
+  }
+`
+  const ModelName = objectType({
+    name: 'ModelName',
+    definition(t: any) {
+      t.model.id()
+    },
+  })
+
+  const Mutation = objectType({
+    name: 'Mutation',
+    definition(t: any) {
+      t.crud.createOneModelName()
+      t.crud.deleteOneModelName()
+      t.crud.updateOneModelName()
+      t.crud.upsertOneModelName()
+      t.crud.updateManyModelName()
+    },
+  })
+
+  const { schemaString: schema, typegen } = await generateSchemaAndTypes(datamodel, [Mutation, ModelName], {
+    atomicOperations: false,
+  })
+
+  expect(schema).toMatchSnapshot('schema')
+  expect(typegen).toMatchSnapshot('typegen')
+})


### PR DESCRIPTION
GraphQL doesn't support union types. The plugin has to apply a  flattening heuristic and pick by default the broadest member of the union. On update and upsert, the broadest member is the atomic operation, which is not ideal in many cases...
This option disables atomic operations and come back to scalar values.

The default value is false to avoid any breaking change with the latest version

fixes #830 


