### PR TITLE
fix: Cannot find module 'semver' 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "fs-jetpack": "^4.0.0",
     "lodash": "^4.17.20",
     "outdent": "^0.7.1",
-    "pluralize": "^8.0.0"
+    "pluralize": "^8.0.0",
+    "semver": "7.3.2"
   },
   "devDependencies": {
     "@nexus/schema": "0.15.0",
@@ -71,7 +72,6 @@
     "node-fetch": "2.6.1",
     "prettier": "2.0.5",
     "rimraf": "3.0.2",
-    "semver": "7.3.2",
     "strip-ansi": "6.0.0",
     "ts-jest": "26.4.1",
     "ts-morph": "8.1.2",


### PR DESCRIPTION
Now that semver is used at runtime it should be placed in dependencies.