### PR TITLE
feat(deps): add support for Prisma 2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@nexus/schema": "0.19.x",
-    "@prisma/client": "2.12.x",
+    "@prisma/client": "2.13.x",
     "graphql": "^15.3.0"
   },
   "dependencies": {
@@ -47,12 +47,12 @@
   "devDependencies": {
     "@nexus/schema": "0.19.0",
     "@prisma-labs/prettier-config": "0.1.0",
-    "@prisma/cli": "2.12.0",
-    "@prisma/client": "2.12.0",
-    "@prisma/fetch-engine": "2.12.0",
-    "@prisma/get-platform": "2.12.0",
-    "@prisma/migrate": "2.12.0",
-    "@prisma/sdk": "2.12.0",
+    "@prisma/cli": "2.13.0",
+    "@prisma/client": "2.13.0",
+    "@prisma/fetch-engine": "2.13.0",
+    "@prisma/get-platform": "2.13.0",
+    "@prisma/migrate": "2.13.0",
+    "@prisma/sdk": "2.13.0",
     "@types/jest": "26.0.15",
     "@types/lodash": "4.14.165",
     "@types/node": "14.14.10",

--- a/tests/__snapshots__/app.test.ts.snap
+++ b/tests/__snapshots__/app.test.ts.snap
@@ -1018,7 +1018,7 @@ Object {
           ],
         },
         Object {
-          "name": "BubbleDistinctFieldEnum",
+          "name": "BubbleScalarFieldEnum",
           "values": Array [
             "id",
             "createdAt",
@@ -1026,7 +1026,7 @@ Object {
           ],
         },
         Object {
-          "name": "UserDistinctFieldEnum",
+          "name": "UserScalarFieldEnum",
           "values": Array [
             "id",
             "firstName",
@@ -1036,7 +1036,7 @@ Object {
           ],
         },
         Object {
-          "name": "LocationDistinctFieldEnum",
+          "name": "LocationScalarFieldEnum",
           "values": Array [
             "id",
             "country",
@@ -1044,7 +1044,7 @@ Object {
           ],
         },
         Object {
-          "name": "PostDistinctFieldEnum",
+          "name": "PostScalarFieldEnum",
           "values": Array [
             "id",
             "rating",
@@ -1060,7 +1060,7 @@ Object {
           ],
         },
         Object {
-          "name": "BubbleDistinctFieldEnum",
+          "name": "BubbleScalarFieldEnum",
           "values": Array [
             "id",
             "createdAt",
@@ -1068,7 +1068,7 @@ Object {
           ],
         },
         Object {
-          "name": "UserDistinctFieldEnum",
+          "name": "UserScalarFieldEnum",
           "values": Array [
             "id",
             "firstName",
@@ -1078,7 +1078,7 @@ Object {
           ],
         },
         Object {
-          "name": "LocationDistinctFieldEnum",
+          "name": "LocationScalarFieldEnum",
           "values": Array [
             "id",
             "country",
@@ -1086,7 +1086,7 @@ Object {
           ],
         },
         Object {
-          "name": "PostDistinctFieldEnum",
+          "name": "PostScalarFieldEnum",
           "values": Array [
             "id",
             "rating",
@@ -1104,7 +1104,7 @@ Object {
       ],
       "prisma": Array [
         Object {
-          "name": "BubbleDistinctFieldEnum",
+          "name": "BubbleScalarFieldEnum",
           "values": Array [
             "id",
             "createdAt",
@@ -1112,7 +1112,7 @@ Object {
           ],
         },
         Object {
-          "name": "UserDistinctFieldEnum",
+          "name": "UserScalarFieldEnum",
           "values": Array [
             "id",
             "firstName",
@@ -1122,7 +1122,7 @@ Object {
           ],
         },
         Object {
-          "name": "LocationDistinctFieldEnum",
+          "name": "LocationScalarFieldEnum",
           "values": Array [
             "id",
             "country",
@@ -1130,7 +1130,7 @@ Object {
           ],
         },
         Object {
-          "name": "PostDistinctFieldEnum",
+          "name": "PostScalarFieldEnum",
           "values": Array [
             "id",
             "rating",
@@ -8060,7 +8060,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "UserDistinctFieldEnum",
+                      "type": "UserScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -8182,7 +8182,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "PostDistinctFieldEnum",
+                      "type": "PostScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -8383,7 +8383,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "UserDistinctFieldEnum",
+                      "type": "UserScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -8494,7 +8494,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "UserDistinctFieldEnum",
+                      "type": "UserScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -8630,7 +8630,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "BubbleDistinctFieldEnum",
+                      "type": "BubbleScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -8725,7 +8725,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "BubbleDistinctFieldEnum",
+                      "type": "BubbleScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -8813,19 +8813,6 @@ Object {
                   "isNullable": false,
                   "isRequired": false,
                   "name": "skip",
-                },
-                Object {
-                  "inputTypes": Array [
-                    Object {
-                      "isList": true,
-                      "location": "enumTypes",
-                      "namespace": "prisma",
-                      "type": "BubbleDistinctFieldEnum",
-                    },
-                  ],
-                  "isNullable": false,
-                  "isRequired": false,
-                  "name": "distinct",
                 },
               ],
               "isNullable": false,
@@ -8941,7 +8928,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "UserDistinctFieldEnum",
+                      "type": "UserScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -9036,7 +9023,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "UserDistinctFieldEnum",
+                      "type": "UserScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -9124,19 +9111,6 @@ Object {
                   "isNullable": false,
                   "isRequired": false,
                   "name": "skip",
-                },
-                Object {
-                  "inputTypes": Array [
-                    Object {
-                      "isList": true,
-                      "location": "enumTypes",
-                      "namespace": "prisma",
-                      "type": "UserDistinctFieldEnum",
-                    },
-                  ],
-                  "isNullable": false,
-                  "isRequired": false,
-                  "name": "distinct",
                 },
               ],
               "isNullable": false,
@@ -9252,7 +9226,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "LocationDistinctFieldEnum",
+                      "type": "LocationScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -9347,7 +9321,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "LocationDistinctFieldEnum",
+                      "type": "LocationScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -9435,19 +9409,6 @@ Object {
                   "isNullable": false,
                   "isRequired": false,
                   "name": "skip",
-                },
-                Object {
-                  "inputTypes": Array [
-                    Object {
-                      "isList": true,
-                      "location": "enumTypes",
-                      "namespace": "prisma",
-                      "type": "LocationDistinctFieldEnum",
-                    },
-                  ],
-                  "isNullable": false,
-                  "isRequired": false,
-                  "name": "distinct",
                 },
               ],
               "isNullable": false,
@@ -9563,7 +9524,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "PostDistinctFieldEnum",
+                      "type": "PostScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -9658,7 +9619,7 @@ Object {
                       "isList": true,
                       "location": "enumTypes",
                       "namespace": "prisma",
-                      "type": "PostDistinctFieldEnum",
+                      "type": "PostScalarFieldEnum",
                     },
                   ],
                   "isNullable": false,
@@ -9746,19 +9707,6 @@ Object {
                   "isNullable": false,
                   "isRequired": false,
                   "name": "skip",
-                },
-                Object {
-                  "inputTypes": Array [
-                    Object {
-                      "isList": true,
-                      "location": "enumTypes",
-                      "namespace": "prisma",
-                      "type": "PostDistinctFieldEnum",
-                    },
-                  ],
-                  "isNullable": false,
-                  "isRequired": false,
-                  "name": "distinct",
                 },
               ],
               "isNullable": false,
@@ -10713,13 +10661,38 @@ Object {
           "fields": Array [
             Object {
               "args": Array [],
-              "isNullable": false,
-              "isRequired": true,
+              "isNullable": true,
+              "isRequired": false,
               "name": "count",
               "outputType": Object {
                 "isList": false,
-                "location": "scalar",
-                "type": "Int",
+                "location": "outputObjectTypes",
+                "namespace": "prisma",
+                "type": "BubbleCountAggregateOutputType",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "min",
+              "outputType": Object {
+                "isList": false,
+                "location": "outputObjectTypes",
+                "namespace": "prisma",
+                "type": "BubbleMinAggregateOutputType",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "max",
+              "outputType": Object {
+                "isList": false,
+                "location": "outputObjectTypes",
+                "namespace": "prisma",
+                "type": "BubbleMaxAggregateOutputType",
               },
             },
           ],
@@ -10729,13 +10702,14 @@ Object {
           "fields": Array [
             Object {
               "args": Array [],
-              "isNullable": false,
-              "isRequired": true,
+              "isNullable": true,
+              "isRequired": false,
               "name": "count",
               "outputType": Object {
                 "isList": false,
-                "location": "scalar",
-                "type": "Int",
+                "location": "outputObjectTypes",
+                "namespace": "prisma",
+                "type": "UserCountAggregateOutputType",
               },
             },
             Object {
@@ -10793,13 +10767,14 @@ Object {
           "fields": Array [
             Object {
               "args": Array [],
-              "isNullable": false,
-              "isRequired": true,
+              "isNullable": true,
+              "isRequired": false,
               "name": "count",
               "outputType": Object {
                 "isList": false,
-                "location": "scalar",
-                "type": "Int",
+                "location": "outputObjectTypes",
+                "namespace": "prisma",
+                "type": "LocationCountAggregateOutputType",
               },
             },
             Object {
@@ -10857,13 +10832,14 @@ Object {
           "fields": Array [
             Object {
               "args": Array [],
-              "isNullable": false,
-              "isRequired": true,
+              "isNullable": true,
+              "isRequired": false,
               "name": "count",
               "outputType": Object {
                 "isList": false,
-                "location": "scalar",
-                "type": "Int",
+                "location": "outputObjectTypes",
+                "namespace": "prisma",
+                "type": "PostCountAggregateOutputType",
               },
             },
             Object {
@@ -10937,6 +10913,202 @@ Object {
           "fields": Array [
             Object {
               "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "id",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "createdAt",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "private",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": false,
+              "isRequired": true,
+              "name": "_all",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+          ],
+          "name": "BubbleCountAggregateOutputType",
+        },
+        Object {
+          "fields": Array [
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "id",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "createdAt",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "DateTime",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "private",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Boolean",
+              },
+            },
+          ],
+          "name": "BubbleMinAggregateOutputType",
+        },
+        Object {
+          "fields": Array [
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "id",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "createdAt",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "DateTime",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "private",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Boolean",
+              },
+            },
+          ],
+          "name": "BubbleMaxAggregateOutputType",
+        },
+        Object {
+          "fields": Array [
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "id",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "firstName",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "lastName",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "bubbleId",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": false,
+              "isRequired": true,
+              "name": "locationId",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": false,
+              "isRequired": true,
+              "name": "_all",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+          ],
+          "name": "UserCountAggregateOutputType",
+        },
+        Object {
+          "fields": Array [
+            Object {
+              "args": Array [],
               "isNullable": false,
               "isRequired": true,
               "name": "locationId",
@@ -10969,6 +11141,50 @@ Object {
           "fields": Array [
             Object {
               "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "id",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "firstName",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "lastName",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "bubbleId",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
               "isNullable": false,
               "isRequired": true,
               "name": "locationId",
@@ -10985,6 +11201,50 @@ Object {
           "fields": Array [
             Object {
               "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "id",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "firstName",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "lastName",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "bubbleId",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
               "isNullable": false,
               "isRequired": true,
               "name": "locationId",
@@ -10996,6 +11256,55 @@ Object {
             },
           ],
           "name": "UserMaxAggregateOutputType",
+        },
+        Object {
+          "fields": Array [
+            Object {
+              "args": Array [],
+              "isNullable": false,
+              "isRequired": true,
+              "name": "id",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "country",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "city",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": false,
+              "isRequired": true,
+              "name": "_all",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+          ],
+          "name": "LocationCountAggregateOutputType",
         },
         Object {
           "fields": Array [
@@ -11042,6 +11351,28 @@ Object {
                 "type": "Int",
               },
             },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "country",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "city",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
           ],
           "name": "LocationMinAggregateOutputType",
         },
@@ -11058,8 +11389,90 @@ Object {
                 "type": "Int",
               },
             },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "country",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "city",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "String",
+              },
+            },
           ],
           "name": "LocationMaxAggregateOutputType",
+        },
+        Object {
+          "fields": Array [
+            Object {
+              "args": Array [],
+              "isNullable": false,
+              "isRequired": true,
+              "name": "id",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": false,
+              "isRequired": true,
+              "name": "rating",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": false,
+              "isRequired": true,
+              "name": "likes",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "status",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": false,
+              "isRequired": true,
+              "name": "_all",
+              "outputType": Object {
+                "isList": false,
+                "location": "scalar",
+                "type": "Int",
+              },
+            },
+          ],
+          "name": "PostCountAggregateOutputType",
         },
         Object {
           "fields": Array [
@@ -11172,6 +11585,18 @@ Object {
                 "type": "Int",
               },
             },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "status",
+              "outputType": Object {
+                "isList": false,
+                "location": "enumTypes",
+                "namespace": "model",
+                "type": "PostStatus",
+              },
+            },
           ],
           "name": "PostMinAggregateOutputType",
         },
@@ -11208,6 +11633,18 @@ Object {
                 "isList": false,
                 "location": "scalar",
                 "type": "Int",
+              },
+            },
+            Object {
+              "args": Array [],
+              "isNullable": true,
+              "isRequired": false,
+              "name": "status",
+              "outputType": Object {
+                "isList": false,
+                "location": "enumTypes",
+                "namespace": "model",
+                "type": "PostStatus",
               },
             },
           ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,39 +768,38 @@
   resolved "https://registry.yarnpkg.com/@prisma/bar/-/bar-0.0.1.tgz#088c4fbbb79c588391437ade9fd3a85527e753b3"
   integrity sha512-FVLhwVkbfhXlBhroWfIXMLi+3Jh9IEzYp+9z+MUUiw3ZsbcoAil7CN9/QIjHc4/TcCRyRfuSmT7qCnn4O+TjJw==
 
-"@prisma/cli@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.12.0.tgz#1c607e53b23632e01bf0b1ee86b5ab5a8864dfef"
-  integrity sha512-6olsgYNo1WePykEjKD3I49OCu9QKASoLLYV04y5UZxBqwkfxPoD8ppE+kc1nvRF8u+TU0oTLMphNTj2/l6tNsg==
+"@prisma/cli@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.13.0.tgz#ab90152c78a28251c44be1d47a2d06b00578de71"
+  integrity sha512-1hTj9H6gVIH5J5GPQVfeHiYFxUv09HVoThGr0Z2ds4JkVMRw///ZXll7pQJvaF7DUheg7dCNf+AXvwmpfm75tg==
   dependencies:
     "@prisma/bar" "^0.0.1"
-    "@prisma/engines" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+    "@prisma/engines" "2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49"
 
-"@prisma/client@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.12.0.tgz#6910a24607357ea272ecb516f44eb8730bd7bd4c"
-  integrity sha512-OozxNF5I8+amaMLlb7NZK3XbvmUgBRUpq2cqresmIhsrfH/LaOaAr4riDW3cF/YgIEpb4tgPoSUEDI3VKyD4yg==
+"@prisma/client@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.13.0.tgz#2c9bddfced133fbcb35c6bb2ca1b3b172cdc9bc3"
+  integrity sha512-osu9oRFWYNU3s+khj7D0xn28yGbk9nUWPG6VYDGIisBf0OTDB3STisCa0O0k5rzk1GpdxLiGJaHpqIo40RkMLw==
   dependencies:
-    "@prisma/engines-version" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+    "@prisma/engines-version" "2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49"
 
-"@prisma/debug@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.12.0.tgz#15b4df53301ed30dfad9582aabd9f96f17d3701a"
-  integrity sha512-ebBbalHTxEmzxORSPeGl+C58nyjDcOlEN/2vRGiEVr+XocC6NCD0rjcwEjYJqFUt/INJXSja+QYyQpW6OpOIXQ==
+"@prisma/debug@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.13.0.tgz#258cb8d2e79f538875d7d1223a984d90451536d6"
+  integrity sha512-ZXkuIhJtgVzUA+iqJ8B8+K+uVQ3CogXXA8do3PfNY7Xau6l6iGEAC+SP08DjA35T4DvPwrPZFd++LscpeuviSw==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/engine-core@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.12.0.tgz#59bb9761f46f69ca029bb4f2ce1949c1d29ecd34"
-  integrity sha512-NnHZT0iqew9i9LN60BiI4rN2u99h3wetf3sVlJuF1Md5NYDRmJdFcoRBPKeNQ9ZsCVo7iAbxYR9TEMxK02HsYg==
+"@prisma/engine-core@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.13.0.tgz#b1befe1e638e938e90dbbb14210554da54eabe75"
+  integrity sha512-EeypNXecVwnmxl32aBA782QIVlNr0uSxf8tMdFfK57XWTxErBQBUJARiVVN8/xVKu4lNiJd9VlVAUHNEKPuhgg==
   dependencies:
-    "@prisma/debug" "2.12.0"
-    "@prisma/engines" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
-    "@prisma/generator-helper" "2.12.0"
-    "@prisma/get-platform" "2.12.0"
+    "@prisma/debug" "2.13.0"
+    "@prisma/engines" "2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49"
+    "@prisma/generator-helper" "2.13.0"
+    "@prisma/get-platform" "2.13.0"
     chalk "^4.0.0"
-    cross-fetch "^3.0.4"
     execa "^4.0.2"
     get-stream "^6.0.0"
     indent-string "^4.0.0"
@@ -809,23 +808,23 @@
     terminal-link "^2.1.1"
     undici "2.2.0"
 
-"@prisma/engines-version@2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58":
-  version "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58.tgz#428f8996f88c92a4142e35f196584a5e17c95871"
-  integrity sha512-IHb/Jag1Wmoq5tLZhOHP5zqLHEXqQEfrHb6l0drIBSvh2AF7yWQ3yyuD0ZEb1Nq37SvbBgop5wrWMOU8YWFTGQ==
+"@prisma/engines-version@2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49":
+  version "2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49.tgz#e2c25298269a0a89fe0931720695a0fd979fd6f6"
+  integrity sha512-OsToEhPo8OKOW2RmfjrQs1WRWX6omTsrBVMQLYKR7p3ijNBXFjCw9fk4x5xcnLZvADYR/rUIxjEK2YR+r/RK3w==
 
-"@prisma/engines@2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58":
-  version "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58.tgz#0e23c811cfa2f58650bb3c04394b1ac0d9dac78a"
-  integrity sha512-F6RmUZ5JpPWxmGvVDji8c4gepHIGkvYbtuFi0IoDDJVaCVo8yS656stciKFyswI6/BLWXa0X47/MIMbz6nzw7g==
+"@prisma/engines@2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49":
+  version "2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49.tgz#458a4c8d7f1afcaa538d34e34da161fd7b7735dd"
+  integrity sha512-BntRdj/uJQMPRXzcYJv80+NtMq+m6f+PIcCTzOUqKerEo53+ynm4bHo2ocLRLS4XtWovGummDlVgZxgWTRhkAw==
 
-"@prisma/fetch-engine@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.12.0.tgz#83e2df4bdd82b65a2f9ea8aa8f3334bfa9678b5e"
-  integrity sha512-2zrzIbvO/9QD8vSeKRaNUCknnq3AJXFCUebLQRlQ/8Z/PabkXzAtQCFxjHItzQSXK8y4/IWjkDva8bJCH4TDSg==
+"@prisma/fetch-engine@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.13.0.tgz#af40a79bec4ca96b16ce90e2fc41f0fceda8cd8f"
+  integrity sha512-z0mop+2I6Mdu1iH7M8pQZXWCg6T06xo4NfJ9k2xgAuKYHHlRBTKTbc3eetiegx4OV6wA1jEHxZmkmw2dfJZOYw==
   dependencies:
-    "@prisma/debug" "2.12.0"
-    "@prisma/get-platform" "2.12.0"
+    "@prisma/debug" "2.13.0"
+    "@prisma/get-platform" "2.13.0"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -843,31 +842,32 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.12.0.tgz#f463e2ed1c79afce0d5776b2e25763299cc526f8"
-  integrity sha512-IYkvhOGzGWmltE/wPHF33iJQGr704023bpB/urPrEuVnwtBihYeQZ4JtH4cJL7BNwxG4PiZMVQr1J8Fs66tWww==
+"@prisma/generator-helper@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.13.0.tgz#32ab45acd0a602212ce588461cedae918e45008c"
+  integrity sha512-SO65Sig6q2FAQOAnbPXDEds3srMzJn92dsFSYpXHz4IzVOqmEl6U2F/cnDIDACyIsQ3BsoqndqIRIxq9rE+2vw==
   dependencies:
-    "@prisma/debug" "2.12.0"
+    "@prisma/debug" "2.13.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.12.0.tgz#f4f3ad534c2a79d2661c85eb3014f26d33c4c501"
-  integrity sha512-gQkmEGWFjpTRbL2u5sCu4oY0q4Kf0e2FsSdhki6WopnQs90aHPjuCPt1dmJHggbRgoGBGrb9V6cr/bSD+FGdew==
+"@prisma/get-platform@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.13.0.tgz#8fe7033f928eb5383f435d0fd4e8c588b29d43fc"
+  integrity sha512-Hk4Y/N0QuhOjH8+s4RfKT8TdAp7MrOneU53n6BXzNwY1LkfQgq/vAvqLbp0PTCvKS8rx62IWIoPGk08ok758Rw==
   dependencies:
-    "@prisma/debug" "2.12.0"
+    "@prisma/debug" "2.13.0"
 
-"@prisma/migrate@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@prisma/migrate/-/migrate-2.12.0.tgz#90fbca862ba76b1d978d3d1867ed58b11e4f5886"
-  integrity sha512-xpj7PWCgyUnA47aKhIfICk05EbBrt1GS96ilwnbaSqOFn1bYP9PkWf6h3tuWsUO18CuQyURU8AGh9dAxOafveQ==
+"@prisma/migrate@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@prisma/migrate/-/migrate-2.13.0.tgz#16ee1cb38a5ad74c34e58a9e76af62e26863ba7c"
+  integrity sha512-JXEgHWG15VYi9V4JLeeSZuU+BoNDBfplusK9fWOCv2AUqx3O/WFi64H4McdoHpAXXpWuJPj5uzKPEAjbtDO4pA==
   dependencies:
-    "@prisma/debug" "2.12.0"
-    "@prisma/fetch-engine" "2.12.0"
-    "@prisma/get-platform" "2.12.0"
+    "@prisma/debug" "2.13.0"
+    "@prisma/fetch-engine" "2.13.0"
+    "@prisma/get-platform" "2.13.0"
+    "@sindresorhus/slugify" "^1.1.0"
     ansi-escapes "^4.3.1"
     cli-cursor "3.1.0"
     dashify "2.0.0"
@@ -891,22 +891,22 @@
     strip-ansi "^6.0.0"
     strip-indent "^3.0.0"
 
-"@prisma/sdk@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.12.0.tgz#fdb7543dc6344a3258936b02c47723357522f867"
-  integrity sha512-LgfYWC5ysGQcZ2IE04QC8hR49CONhcv8RscL1EH5rl1c7BTLBQ/jQZURb0ODPWLLkF+8ND0OUadNGHbxG0KKDQ==
+"@prisma/sdk@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.13.0.tgz#b33ac228a65c95e391913cbb4a5c6eb9130a1078"
+  integrity sha512-QphvrF2NDBJ2v76CIhGCzJLwn+j9rw1OPqLKrNLIeIbXvHdS7UWEi3c+0gAwQ1Qc1a4YFnynZNRCSDEBQlwGiQ==
   dependencies:
-    "@prisma/debug" "2.12.0"
-    "@prisma/engine-core" "2.12.0"
-    "@prisma/engines" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
-    "@prisma/fetch-engine" "2.12.0"
-    "@prisma/generator-helper" "2.12.0"
-    "@prisma/get-platform" "2.12.0"
+    "@prisma/debug" "2.13.0"
+    "@prisma/engine-core" "2.13.0"
+    "@prisma/engines" "2.13.0-32.833ab05d2a20e822f6736a39a27de4fc8f6b3e49"
+    "@prisma/fetch-engine" "2.13.0"
+    "@prisma/generator-helper" "2.13.0"
+    "@prisma/get-platform" "2.13.0"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
     chalk "4.1.0"
-    checkpoint-client "1.1.14"
+    checkpoint-client "1.1.17"
     cli-truncate "^2.1.0"
     dotenv "^8.2.0"
     execa "^4.0.0"
@@ -931,6 +931,22 @@
     terminal-link "^2.1.1"
     tmp "0.2.1"
     url-parse "^1.4.7"
+
+"@sindresorhus/slugify@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/slugify/-/slugify-1.1.0.tgz#2f195365d9b953384305b62664b44b4036c49430"
+  integrity sha512-ujZRbmmizX26yS/HnB3P9QNlNa4+UvHh+rIse3RbOXLp8yl6n1TxB4t7NHggtVgS8QmmOtzXo48kCxZGACpkPw==
+  dependencies:
+    "@sindresorhus/transliterate" "^0.1.1"
+    escape-string-regexp "^4.0.0"
+
+"@sindresorhus/transliterate@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/transliterate/-/transliterate-0.1.1.tgz#779b31244781d3c898f185b61d58c89e7c782674"
+  integrity sha512-QSdIQ5keUFAZ3KLbfbsntW39ox0Ym8183RqTwBq/ZEFoN3NQAtGV+qWaNdzKpIDHgj9J2CQ2iNDRVU11Zyr7MQ==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+    lodash.deburr "^4.1.0"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
@@ -1895,10 +1911,10 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-checkpoint-client@1.1.14:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.14.tgz#45d58ae4f9d24c029fb35f5afc8cd6cacfed4e36"
-  integrity sha512-/3wj7LeYK/J/e4pF+WG1JNpRZ3GggoXelgdY8I4VSzmlrlRUe9vJhJQySqYdVrCGe7O6VlfJ1GVlnmw7p8XAKg==
+checkpoint-client@1.1.17:
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.17.tgz#f694648bf8f8b545b7aec502e0561cca97643b6e"
+  integrity sha512-j5qx5/i5Cw07XRsY0sc8OmU+WGKr1LluQ1wkdjBA+aXTvFlH8pfe0jJaPpciMZG3QDo27LuDdMlImRcuQUvmdQ==
   dependencies:
     ci-info "2.0.0"
     cross-spawn "7.0.3"
@@ -2144,7 +2160,7 @@ crc@^3.4.4:
   dependencies:
     buffer "^5.1.0"
 
-cross-fetch@^3.0.4, cross-fetch@^3.0.6:
+cross-fetch@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
   integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
@@ -2465,7 +2481,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@4.0.0:
+escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
@@ -4319,6 +4335,11 @@ lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+
+lodash.deburr@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
+  integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
 
 lodash.defaults@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
closes #956

No breaking changes to the generated GraphQL API detected.

BREAKING CHANGE:

Peer dependency requirement for `@prisma/client` raised from 2.12 to 2.13

No actual breaking changes beyond this are known, but we're still labelling this as a breaking change as it technically introduces backwards incompatible package requirements.