### PR TITLE
feat: Add CommonFieldConfig to NexusPrismaScalarOpts

### DIFF
--- a/src/typegen/static.ts
+++ b/src/typegen/static.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 import { GraphQLResolveInfo } from 'graphql'
 import { core } from 'nexus'
+import { CommonFieldConfig } from 'nexus/dist/core'
 import * as Helpers from './helpers'
 
 // todo remove framework types from here once
@@ -61,7 +62,8 @@ type NexusPrismaScalarOpts<
    * ```
    */
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
-} & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
+} & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias> &
+  CommonFieldConfig
 
 type RootObjectTypes = Pick<core.GetGen<'rootTypes'>, core.GetGen<'objectNames'>>
 

--- a/tests/schema/__snapshots__/commonFieldConfig.test.ts.snap
+++ b/tests/schema/__snapshots__/commonFieldConfig.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`forwards common fields on scalars: commonFieldsOutput 1`] = `
+exports[`forwards description & deprecation on all field types: commonFieldsOutput 1`] = `
 "type User {
   \\"\\"\\"The unique id\\"\\"\\"
   id: Int! @deprecated(reason: \\"never\\")

--- a/tests/schema/__snapshots__/commonFieldConfig.test.ts.snap
+++ b/tests/schema/__snapshots__/commonFieldConfig.test.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`forwards common fields on scalars: commonFieldsOutput 1`] = `
+"type User {
+  \\"\\"\\"The unique id\\"\\"\\"
+  id: Int! @deprecated(reason: \\"never\\")
+
+  \\"\\"\\"The user's full name\\"\\"\\"
+  name: String! @deprecated(reason: \\"who needs names\\")
+
+  \\"\\"\\"The user's height, in meters\\"\\"\\"
+  heightM: Float! @deprecated(reason: \\"size doesn't matter\\")
+
+  \\"\\"\\"The user's favorite color\\"\\"\\"
+  favouriteColor: Color! @deprecated(reason: \\"no longer required\\")
+
+  \\"\\"\\"All the user's blog posts\\"\\"\\"
+  posts(first: Int, last: Int, before: PostWhereUniqueInput, after: PostWhereUniqueInput): [Post!]! @deprecated(reason: \\"no more blog\\")
+
+  \\"\\"\\"The user's last blog post\\"\\"\\"
+  latestPost: Post @deprecated(reason: \\"not here anymore\\")
+}
+
+type Post {
+  id: Int!
+}
+
+enum Color {
+  Red
+  Green
+  Blue
+}
+
+input PostWhereUniqueInput {
+  id: Int
+}
+
+type Query {
+  ok: Boolean!
+}
+"
+`;

--- a/tests/schema/commonFieldConfig.test.ts
+++ b/tests/schema/commonFieldConfig.test.ts
@@ -1,0 +1,56 @@
+import { objectType } from '@nexus/schema'
+import { generateSchemaAndTypes } from '../__utils'
+
+it('forwards description & deprecation on all field types', async () => {
+  const datamodel = `
+    model User {
+      id  Int @id @default(autoincrement())
+
+      name String
+      emailConfirmed Boolean
+      birthYear Int
+      heightM Float
+
+      favouriteColor  Color
+
+      latestPost Post? @relation("latestPostId")
+      posts Post[] @relation("userId")
+    }
+
+    enum Color {
+      Red
+      Green
+      Blue
+    }
+
+    model Post {
+      id  Int @id @default(autoincrement())
+      title String
+      body String
+      user User @relation("userId")
+    }
+  `
+
+  const Post = objectType({
+    name: 'Post',
+    definition(t) {
+      t.model.id()
+    },
+  })
+
+  const User = objectType({
+    name: 'User',
+    definition(t: any) {
+      t.model.id({ description: 'The unique id', deprecation: 'never' })
+      t.model.name({ description: "The user's full name", deprecation: 'who needs names' })
+      t.model.heightM({ description: "The user's height, in meters", deprecation: "size doesn't matter" })
+      t.model.favouriteColor({ description: "The user's favorite color", deprecation: 'no longer required' })
+      t.model.posts({ description: "All the user's blog posts", deprecation: 'no more blog' })
+      t.model.latestPost({ description: "The user's last blog post", deprecation: 'not here anymore' })
+    },
+  })
+
+  const { schemaString: schema } = await generateSchemaAndTypes(datamodel, [User, Post])
+
+  expect(schema).toMatchSnapshot('commonFieldsOutput')
+})

--- a/tests/schema/commonFieldConfig.test.ts
+++ b/tests/schema/commonFieldConfig.test.ts
@@ -1,4 +1,4 @@
-import { objectType } from '@nexus/schema'
+import * as Nexus from 'nexus'
 import { generateSchemaAndTypes } from '../__utils'
 
 it('forwards description & deprecation on all field types', async () => {
@@ -31,14 +31,14 @@ it('forwards description & deprecation on all field types', async () => {
     }
   `
 
-  const Post = objectType({
+  const Post = Nexus.objectType({
     name: 'Post',
-    definition(t) {
+    definition(t: any) {
       t.model.id()
     },
   })
 
-  const User = objectType({
+  const User = Nexus.objectType({
     name: 'User',
     definition(t: any) {
       t.model.id({ description: 'The unique id', deprecation: 'never' })


### PR DESCRIPTION
Resolves #752 

Adds description and deprecation fields to NexusPrismaScalarOpts by forwarding them directly from the relevant Nexus type. Pulling directly from their interface will prevent type errors should the CommonFieldConfig change in the future.

Both of these fields were already functioning properly, this just fixes the type error when they're supplied.

I tested against my project and confirmed that my type errors were resolved, and property descriptions showed up in VS Code.