### PR TITLE
fix: common options to CRUD typings

### DIFF
--- a/src/typegen/static.ts
+++ b/src/typegen/static.ts
@@ -169,7 +169,8 @@ type BaseRelationOptions<
    */
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
   computedInputs?: LocalComputedInputs<MethodName>
-} & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias>
+} & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias> &
+CommonFieldConfig
 
 // If GetNexusPrismaInput returns never, it means there are no filtering/ordering args for it.
 type NexusPrismaRelationOpts<


### PR DESCRIPTION
Add CommonFieldConfig to BaseRelationOptions to allow to pass common options such as `description` & `deprecation` to the CRUD configuration.

This should fix #1037