### PR TITLE
feat: export BaseRelationOptions type

### DIFF
--- a/src/typegen/static.ts
+++ b/src/typegen/static.ts
@@ -140,7 +140,7 @@ export type LocalMutationResolverParams<MethodName extends string> = BaseMutatio
 
 export type Context = core.GetGen<'context'>
 
-type BaseRelationOptions<
+export type BaseRelationOptions<
   TypeName extends string,
   MethodName extends string,
   Alias extends string | undefined,


### PR DESCRIPTION
When writing extensions to work with nexus-plugin-prisma we need this type to be exported.