### PR TITLE
fix: allow orderByRelation preview feature #1063

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -655,9 +655,13 @@ export class SchemaBuilder {
 
     if (publisherConfig.ordering) {
       const orderByTypeName = `${field.outputType.type}OrderByInput`
+      const orderByTypeNamePreviewFeature = `${field.outputType.type}OrderByWithRelationInput`
       const orderByArg = field.args.find(
-        (arg) => arg.inputType.type === orderByTypeName && arg.name === 'orderBy'
-      )
+        (arg) =>
+          (arg.inputType.type === orderByTypeName ||
+            arg.inputType.type === orderByTypeNamePreviewFeature) &&
+          arg.name === 'orderBy'
+      );
 
       if (!orderByArg) {
         throw new Error(`Could not find ordering argument for ${typeName}.${field.name}`)
@@ -665,7 +669,7 @@ export class SchemaBuilder {
 
       const inputType = this.handleInputObjectCustomization({
         fieldWhitelist: publisherConfig.ordering,
-        inputTypeName: orderByTypeName,
+        inputTypeName: orderByArg.inputType.type,
         fieldName: field.name,
         graphQLTypeName: typeName,
         isWhereType: false,


### PR DESCRIPTION
Closes #1063 

When using Prisma's `orderByRelation` preview feature, the generated typename suffix for the ordering input type is `OrderByWithRelationInput`. Nexus plugin prisma was not taking this into account, and still looked for the original suffix `OrderByInput`. This fix accounts for the preview feature being enabled or disabled.

Pinging @jasonkuhrt because we've discussed this.