### PR TITLE
feat: Add computed where input

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -359,7 +359,7 @@ export class SchemaBuilder {
                 whereArgs &&
                 whereInputType &&
                 (!isEmptyObject(publisherConfig.locallyComputedWhereInputs) ||
-                  !isEmptyObject(this.globallyComputedInputs))
+                  !isEmptyObject(this.globallyComputedWhereInputs))
               ) {
                 args = await addComputedWhereInputs({
                   argType: whereArgs.inputType.type,

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -246,6 +246,7 @@ export class SchemaBuilder {
   protected publisher: Publisher
   protected scalars: Record<string, GraphQLScalarType>
   protected globallyComputedInputs: GlobalComputedInputs
+  protected globallyComputedWhereInputs: GlobalComputedWhereInputs
   protected unknownFieldsByModel: Index<string[]>
   public wasCrudUsedButDisabled: boolean
 
@@ -258,11 +259,13 @@ export class SchemaBuilder {
     }
     // Internally rename the 'computedInputs' plugin option to clarify scope
     this.globallyComputedInputs = config.computedInputs ? config.computedInputs : {}
+    this.globallyComputedWhereInputs = config.computedWhereInputs ? config.computedWhereInputs : {}
     this.paginationStrategy = paginationStrategies[config.paginationStrategy]
     this.dmmf =
       options.dmmf ||
       getTransformedDmmf(config.inputs.prismaClient, {
         globallyComputedInputs: this.globallyComputedInputs,
+        globallyComputedWhereInputs: this.globallyComputedWhereInputs,
         paginationStrategy: this.paginationStrategy,
         atomicOperations: config.atomicOperations,
       })

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -375,7 +375,6 @@ export class SchemaBuilder {
               }
 
               args = this.paginationStrategy.resolve(args)
-
               return prismaClient[mappedField.prismaClientAccessor][mappedField.operation](args)
             }
 
@@ -689,7 +688,12 @@ export class SchemaBuilder {
       if (inputType.fields.length > 0) {
         args.push({
           arg: whereArg,
-          type: inputType,
+          type: {
+            ...inputType,
+            fields: inputType.fields.filter(
+              (filed) => !Object.keys(publisherConfig.locallyComputedWhereInputs).includes(filed.name)
+            ),
+          },
         })
       }
     }

--- a/src/dmmf/DmmfTypes.ts
+++ b/src/dmmf/DmmfTypes.ts
@@ -1,4 +1,4 @@
-import { GlobalComputedInputs } from '../utils'
+import { GlobalComputedInputs, GlobalComputedWhereInputs } from '../utils'
 
 export declare namespace InternalDMMF {
   interface Document {
@@ -93,6 +93,7 @@ export declare namespace InternalDMMF {
     }
     fields: SchemaArg[]
     computedInputs: GlobalComputedInputs
+    computedWhereInputs: GlobalComputedWhereInputs
   }
   interface Mapping {
     model: string

--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -333,27 +333,26 @@ async function addGloballyComputedWhereInputs({
     }
   }, Promise.resolve({} as Record<string, any>))
 
-  const test = await Object.keys(where).reduce(async (deeplyComputedData, fieldName) => {
+  // Combine computedInputValues with values provided by the user, recursing to add
+  // global computedInputs to nested types
+  return await Object.keys(where).reduce(async (deeplyComputedData, fieldName) => {
     const field = inputType.fields.find((_) => _.name === fieldName)!
     const fieldValue =
-      field.inputType.kind === 'object' && typeof where[fieldName] === 'object' && where[fieldName] !== null
-        ? await addGloballyComputedWhereInputs({
-            argType: field.inputType.type,
-            inputType: dmmf.getInputType(field.inputType.type),
-            dmmf,
-            params,
-            where: where[fieldName],
-          })
-        : where[fieldName]
+        field.inputType.kind === 'object' && typeof where[fieldName] === 'object' && where[fieldName] !== null
+            ? await addGloballyComputedWhereInputs({
+              argType: field.inputType.type,
+              inputType: dmmf.getInputType(field.inputType.type),
+              dmmf,
+              params,
+              where: where[fieldName],
+            })
+            : where[fieldName]
 
     return {
       [fieldName]: fieldValue,
       ...(await deeplyComputedData),
     }
   }, computedInputValues)
-  // Combine computedInputValues with values provided by the user, recursing to add
-  // global computedInputs to nested types
-  return test
 }
 
 export async function addComputedWhereInputs({

--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -338,15 +338,15 @@ async function addGloballyComputedWhereInputs({
   return await Object.keys(where).reduce(async (deeplyComputedData, fieldName) => {
     const field = inputType.fields.find((_) => _.name === fieldName)!
     const fieldValue =
-        field.inputType.kind === 'object' && typeof where[fieldName] === 'object' && where[fieldName] !== null
-            ? await addGloballyComputedWhereInputs({
-              argType: field.inputType.type,
-              inputType: dmmf.getInputType(field.inputType.type),
-              dmmf,
-              params,
-              where: where[fieldName],
-            })
-            : where[fieldName]
+      field.inputType.kind === 'object' && typeof where[fieldName] === 'object' && where[fieldName] !== null
+        ? await addGloballyComputedWhereInputs({
+            argType: field.inputType.type,
+            inputType: dmmf.getInputType(field.inputType.type),
+            dmmf,
+            params,
+            where: where[fieldName],
+          })
+        : where[fieldName]
 
     return {
       [fieldName]: fieldValue,

--- a/src/typegen/static.ts
+++ b/src/typegen/static.ts
@@ -116,25 +116,38 @@ type GetNexusPrismaInput<
  *  the request's input and returns the value to pass to the prisma
  *  arg of the same name.
  */
-export type LocalComputedInputs<MethodName extends string> = Record<
+export declare type LocalComputedInputs<MethodName extends string> = Record<
   string,
   (params: LocalMutationResolverParams<MethodName>) => unknown
 >
-
-export type GlobalComputedInputs = Record<string, (params: GlobalMutationResolverParams) => unknown>
-
-type BaseMutationResolverParams = {
+export declare type LocalComputedWhereInputs<MethodName extends string> = Record<
+  string,
+  (params: LocalQueryResolverParams<MethodName>) => unknown
+>
+export declare type GlobalComputedInputs = Record<string, (params: GlobalMutationResolverParams) => unknown>
+export declare type GlobalComputedWhereInputs = Record<string, (params: GlobalQueryResolverParams) => unknown>
+declare type BaseResolverParams = {
   info: GraphQLResolveInfo
   ctx: Context
 }
-
-export type GlobalMutationResolverParams = BaseMutationResolverParams & {
-  args: Record<string, any> & { data: unknown }
+export declare type GlobalMutationResolverParams = BaseResolverParams & {
+  args: Record<string, any> & {
+    data: unknown
+  }
 }
-
-export type LocalMutationResolverParams<MethodName extends string> = BaseMutationResolverParams & {
+export declare type GlobalQueryResolverParams = BaseResolverParams & {
+  args: Record<string, any> & {
+    where?: unknown
+  }
+}
+export declare type LocalMutationResolverParams<MethodName extends string> = BaseResolverParams & {
   args: MethodName extends keyof core.GetGen2<'argTypes', 'Mutation'>
     ? core.GetGen3<'argTypes', 'Mutation', MethodName>
+    : any
+}
+export declare type LocalQueryResolverParams<MethodName extends string> = BaseResolverParams & {
+  args: MethodName extends keyof core.GetGen2<'argTypes', 'Query'>
+    ? core.GetGen3<'argTypes', 'Query', MethodName>
     : any
 }
 
@@ -169,8 +182,9 @@ export type BaseRelationOptions<
    */
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
   computedInputs?: LocalComputedInputs<MethodName>
+  computedWhereInputs?: LocalComputedWhereInputs<MethodName>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias> &
-CommonFieldConfig
+  CommonFieldConfig
 
 // If GetNexusPrismaInput returns never, it means there are no filtering/ordering args for it.
 type NexusPrismaRelationOpts<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,20 +156,44 @@ export type LocalComputedInputs<MethodName extends string> = Record<
   (params: LocalMutationResolverParams<MethodName>) => unknown
 >
 
-export type GlobalComputedInputs = Record<string, (params: GlobalMutationResolverParams) => unknown>
+/**
+ *  Represents arguments required by Prisma Client JS that will
+ *  be derived from a request's input (args, context, and info)
+ *  and omitted from the GraphQL API. The object itself maps the
+ *  names of these args to a function that takes an object representing
+ *  the request's input and returns the value to pass to the prisma
+ *  arg of the same name.
+ */
+export type LocalComputedWhereInputs<MethodName extends string> = Record<
+  string,
+  (params: LocalMutationResolverParams<MethodName>) => unknown
+>
 
-type BaseMutationResolverParams = {
+export type GlobalComputedInputs = Record<string, (params: GlobalMutationResolverParams) => unknown>
+export type GlobalComputedWhereInputs = Record<string, (params: GlobalQueryResolverParams) => unknown>
+
+type BaseResolverParams = {
   info: GraphQLResolveInfo
   ctx: Context
 }
 
-export type GlobalMutationResolverParams = BaseMutationResolverParams & {
+export type GlobalMutationResolverParams = BaseResolverParams & {
   args: Record<string, any> & { data: unknown }
 }
 
-export type LocalMutationResolverParams<MethodName extends string> = BaseMutationResolverParams & {
+export type GlobalQueryResolverParams = BaseResolverParams & {
+  args: Record<string, any> & { where?: unknown }
+}
+
+export type LocalMutationResolverParams<MethodName extends string> = BaseResolverParams & {
   args: MethodName extends keyof core.GetGen2<'argTypes', 'Mutation'>
     ? core.GetGen3<'argTypes', 'Mutation', MethodName>
+    : any
+}
+
+export type LocalQueryResolverParams<MethodName extends string> = BaseResolverParams & {
+  args: MethodName extends keyof core.GetGen2<'argTypes', 'Query'>
+    ? core.GetGen3<'argTypes', 'Query', MethodName>
     : any
 }
 

--- a/tests/__app/generated/nexus-plugin-prisma-typegen.d.ts
+++ b/tests/__app/generated/nexus-plugin-prisma-typegen.d.ts
@@ -1,12 +1,12 @@
 import * as Typegen from '../../../src/typegen/static'
-import * as Prisma from '@prisma/client';
+import * as Prisma from '@prisma/client'
 
 // Pagination type
 type Pagination = {
-    first?: boolean
-    last?: boolean
-    before?: boolean
-    after?: boolean
+  first?: boolean
+  last?: boolean
+  before?: boolean
+  after?: boolean
 }
 
 // Prisma custom scalar names
@@ -28,7 +28,18 @@ interface NexusPrismaInputs {
       ordering: 'id' | 'createdAt' | 'private'
     }
     users: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'posts' | 'firstName' | 'lastName' | 'location' | 'Bubble' | 'bubbleId' | 'locationId'
+      filtering:
+        | 'AND'
+        | 'OR'
+        | 'NOT'
+        | 'id'
+        | 'posts'
+        | 'firstName'
+        | 'lastName'
+        | 'location'
+        | 'Bubble'
+        | 'bubbleId'
+        | 'locationId'
       ordering: 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId'
     }
     locations: {
@@ -39,10 +50,21 @@ interface NexusPrismaInputs {
       filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'authors' | 'rating' | 'likes' | 'status'
       ordering: 'id' | 'rating' | 'likes' | 'status'
     }
-  },
+  }
   Bubble: {
     members: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'posts' | 'firstName' | 'lastName' | 'location' | 'Bubble' | 'bubbleId' | 'locationId'
+      filtering:
+        | 'AND'
+        | 'OR'
+        | 'NOT'
+        | 'id'
+        | 'posts'
+        | 'firstName'
+        | 'lastName'
+        | 'location'
+        | 'Bubble'
+        | 'bubbleId'
+        | 'locationId'
       ordering: 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId'
     }
   }
@@ -54,13 +76,35 @@ interface NexusPrismaInputs {
   }
   Location: {
     User: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'posts' | 'firstName' | 'lastName' | 'location' | 'Bubble' | 'bubbleId' | 'locationId'
+      filtering:
+        | 'AND'
+        | 'OR'
+        | 'NOT'
+        | 'id'
+        | 'posts'
+        | 'firstName'
+        | 'lastName'
+        | 'location'
+        | 'Bubble'
+        | 'bubbleId'
+        | 'locationId'
       ordering: 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId'
     }
   }
   Post: {
     authors: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'posts' | 'firstName' | 'lastName' | 'location' | 'Bubble' | 'bubbleId' | 'locationId'
+      filtering:
+        | 'AND'
+        | 'OR'
+        | 'NOT'
+        | 'id'
+        | 'posts'
+        | 'firstName'
+        | 'lastName'
+        | 'location'
+        | 'Bubble'
+        | 'bubbleId'
+        | 'locationId'
       ordering: 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId'
     }
   }
@@ -77,7 +121,7 @@ interface NexusPrismaOutputs {
     locations: 'Location'
     post: 'Post'
     posts: 'Post'
-  },
+  }
   Mutation: {
     createOneBubble: 'Bubble'
     updateOneBubble: 'Bubble'
@@ -103,7 +147,7 @@ interface NexusPrismaOutputs {
     deleteOnePost: 'Post'
     deleteManyPost: 'AffectedRowsOutput'
     upsertOnePost: 'Post'
-  },
+  }
   Bubble: {
     id: 'String'
     createdAt: 'DateTime'
@@ -157,9 +201,8 @@ interface NexusPrismaGenTypes {
 declare global {
   interface NexusPrismaGen extends NexusPrismaGenTypes {}
 
-  type NexusPrisma<
-    TypeName extends string,
-    ModelOrCrud extends 'model' | 'crud'
-  > = Typegen.GetNexusPrisma<TypeName, ModelOrCrud>;
+  type NexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud'> = Typegen.GetNexusPrisma<
+    TypeName,
+    ModelOrCrud
+  >
 }
-  

--- a/tests/__app/generated/nexus-typegen.d.ts
+++ b/tests/__app/generated/nexus-typegen.d.ts
@@ -3,10 +3,6 @@
  * Do not make changes to this file directly
  */
 
-
-
-
-
 declare global {
   interface NexusGenCustomOutputProperties<TypeName extends string> {
     crud: NexusPrisma<TypeName, 'crud'>
@@ -19,294 +15,335 @@ declare global {
 }
 
 export interface NexusGenInputs {
-  BoolFilter: { // input type
-    equals?: boolean | null; // Boolean
-    not?: NexusGenInputs['NestedBoolFilter'] | null; // NestedBoolFilter
+  BoolFilter: {
+    // input type
+    equals?: boolean | null // Boolean
+    not?: NexusGenInputs['NestedBoolFilter'] | null // NestedBoolFilter
   }
-  BubbleCreateNestedOneWithoutMembersInput: { // input type
-    connect?: NexusGenInputs['BubbleWhereUniqueInput'] | null; // BubbleWhereUniqueInput
-    connectOrCreate?: NexusGenInputs['BubbleCreateOrConnectWithoutMembersInput'] | null; // BubbleCreateOrConnectWithoutMembersInput
-    create?: NexusGenInputs['BubbleCreateWithoutMembersInput'] | null; // BubbleCreateWithoutMembersInput
+  BubbleCreateNestedOneWithoutMembersInput: {
+    // input type
+    connect?: NexusGenInputs['BubbleWhereUniqueInput'] | null // BubbleWhereUniqueInput
+    connectOrCreate?: NexusGenInputs['BubbleCreateOrConnectWithoutMembersInput'] | null // BubbleCreateOrConnectWithoutMembersInput
+    create?: NexusGenInputs['BubbleCreateWithoutMembersInput'] | null // BubbleCreateWithoutMembersInput
   }
-  BubbleCreateOrConnectWithoutMembersInput: { // input type
-    create: NexusGenInputs['BubbleCreateWithoutMembersInput']; // BubbleCreateWithoutMembersInput!
-    where: NexusGenInputs['BubbleWhereUniqueInput']; // BubbleWhereUniqueInput!
+  BubbleCreateOrConnectWithoutMembersInput: {
+    // input type
+    create: NexusGenInputs['BubbleCreateWithoutMembersInput'] // BubbleCreateWithoutMembersInput!
+    where: NexusGenInputs['BubbleWhereUniqueInput'] // BubbleWhereUniqueInput!
   }
-  BubbleCreateWithoutMembersInput: { // input type
-    createdAt?: NexusGenScalars['DateTime'] | null; // DateTime
-    id?: string | null; // String
-    private: boolean; // Boolean!
+  BubbleCreateWithoutMembersInput: {
+    // input type
+    createdAt?: NexusGenScalars['DateTime'] | null // DateTime
+    id?: string | null // String
+    private: boolean // Boolean!
   }
-  BubbleMembersOrderByInput: { // input type
-    firstName?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    locationId?: NexusGenEnums['SortOrder'] | null; // SortOrder
+  BubbleMembersOrderByInput: {
+    // input type
+    firstName?: NexusGenEnums['SortOrder'] | null // SortOrder
+    locationId?: NexusGenEnums['SortOrder'] | null // SortOrder
   }
-  BubbleMembersWhereInput: { // input type
-    id?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    location?: NexusGenInputs['LocationWhereInput'] | null; // LocationWhereInput
+  BubbleMembersWhereInput: {
+    // input type
+    id?: NexusGenInputs['StringFilter'] | null // StringFilter
+    location?: NexusGenInputs['LocationWhereInput'] | null // LocationWhereInput
   }
-  BubbleWhereInput: { // input type
-    AND?: NexusGenInputs['BubbleWhereInput'][] | null; // [BubbleWhereInput!]
-    createdAt?: NexusGenInputs['DateTimeFilter'] | null; // DateTimeFilter
-    id?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    members?: NexusGenInputs['UserListRelationFilter'] | null; // UserListRelationFilter
-    NOT?: NexusGenInputs['BubbleWhereInput'][] | null; // [BubbleWhereInput!]
-    OR?: NexusGenInputs['BubbleWhereInput'][] | null; // [BubbleWhereInput!]
-    private?: NexusGenInputs['BoolFilter'] | null; // BoolFilter
+  BubbleWhereInput: {
+    // input type
+    AND?: NexusGenInputs['BubbleWhereInput'][] | null // [BubbleWhereInput!]
+    createdAt?: NexusGenInputs['DateTimeFilter'] | null // DateTimeFilter
+    id?: NexusGenInputs['StringFilter'] | null // StringFilter
+    members?: NexusGenInputs['UserListRelationFilter'] | null // UserListRelationFilter
+    NOT?: NexusGenInputs['BubbleWhereInput'][] | null // [BubbleWhereInput!]
+    OR?: NexusGenInputs['BubbleWhereInput'][] | null // [BubbleWhereInput!]
+    private?: NexusGenInputs['BoolFilter'] | null // BoolFilter
   }
-  BubbleWhereUniqueInput: { // input type
-    id?: string | null; // String
+  BubbleWhereUniqueInput: {
+    // input type
+    id?: string | null // String
   }
-  DateTimeFilter: { // input type
-    equals?: NexusGenScalars['DateTime'] | null; // DateTime
-    gt?: NexusGenScalars['DateTime'] | null; // DateTime
-    gte?: NexusGenScalars['DateTime'] | null; // DateTime
-    in?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
-    lt?: NexusGenScalars['DateTime'] | null; // DateTime
-    lte?: NexusGenScalars['DateTime'] | null; // DateTime
-    not?: NexusGenInputs['NestedDateTimeFilter'] | null; // NestedDateTimeFilter
-    notIn?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
+  DateTimeFilter: {
+    // input type
+    equals?: NexusGenScalars['DateTime'] | null // DateTime
+    gt?: NexusGenScalars['DateTime'] | null // DateTime
+    gte?: NexusGenScalars['DateTime'] | null // DateTime
+    in?: NexusGenScalars['DateTime'][] | null // [DateTime!]
+    lt?: NexusGenScalars['DateTime'] | null // DateTime
+    lte?: NexusGenScalars['DateTime'] | null // DateTime
+    not?: NexusGenInputs['NestedDateTimeFilter'] | null // NestedDateTimeFilter
+    notIn?: NexusGenScalars['DateTime'][] | null // [DateTime!]
   }
-  EnumPostStatusFieldUpdateOperationsInput: { // input type
-    set?: NexusGenEnums['PostStatus'] | null; // PostStatus
+  EnumPostStatusFieldUpdateOperationsInput: {
+    // input type
+    set?: NexusGenEnums['PostStatus'] | null // PostStatus
   }
-  EnumPostStatusFilter: { // input type
-    equals?: NexusGenEnums['PostStatus'] | null; // PostStatus
-    in?: NexusGenEnums['PostStatus'][] | null; // [PostStatus!]
-    not?: NexusGenInputs['NestedEnumPostStatusFilter'] | null; // NestedEnumPostStatusFilter
-    notIn?: NexusGenEnums['PostStatus'][] | null; // [PostStatus!]
+  EnumPostStatusFilter: {
+    // input type
+    equals?: NexusGenEnums['PostStatus'] | null // PostStatus
+    in?: NexusGenEnums['PostStatus'][] | null // [PostStatus!]
+    not?: NexusGenInputs['NestedEnumPostStatusFilter'] | null // NestedEnumPostStatusFilter
+    notIn?: NexusGenEnums['PostStatus'][] | null // [PostStatus!]
   }
-  FloatFieldUpdateOperationsInput: { // input type
-    decrement?: number | null; // Float
-    divide?: number | null; // Float
-    increment?: number | null; // Float
-    multiply?: number | null; // Float
-    set?: number | null; // Float
+  FloatFieldUpdateOperationsInput: {
+    // input type
+    decrement?: number | null // Float
+    divide?: number | null // Float
+    increment?: number | null // Float
+    multiply?: number | null // Float
+    set?: number | null // Float
   }
-  FloatFilter: { // input type
-    equals?: number | null; // Float
-    gt?: number | null; // Float
-    gte?: number | null; // Float
-    in?: number[] | null; // [Float!]
-    lt?: number | null; // Float
-    lte?: number | null; // Float
-    not?: NexusGenInputs['NestedFloatFilter'] | null; // NestedFloatFilter
-    notIn?: number[] | null; // [Float!]
+  FloatFilter: {
+    // input type
+    equals?: number | null // Float
+    gt?: number | null // Float
+    gte?: number | null // Float
+    in?: number[] | null // [Float!]
+    lt?: number | null // Float
+    lte?: number | null // Float
+    not?: NexusGenInputs['NestedFloatFilter'] | null // NestedFloatFilter
+    notIn?: number[] | null // [Float!]
   }
-  IntFieldUpdateOperationsInput: { // input type
-    decrement?: number | null; // Int
-    divide?: number | null; // Int
-    increment?: number | null; // Int
-    multiply?: number | null; // Int
-    set?: number | null; // Int
+  IntFieldUpdateOperationsInput: {
+    // input type
+    decrement?: number | null // Int
+    divide?: number | null // Int
+    increment?: number | null // Int
+    multiply?: number | null // Int
+    set?: number | null // Int
   }
-  IntFilter: { // input type
-    equals?: number | null; // Int
-    gt?: number | null; // Int
-    gte?: number | null; // Int
-    in?: number[] | null; // [Int!]
-    lt?: number | null; // Int
-    lte?: number | null; // Int
-    not?: NexusGenInputs['NestedIntFilter'] | null; // NestedIntFilter
-    notIn?: number[] | null; // [Int!]
+  IntFilter: {
+    // input type
+    equals?: number | null // Int
+    gt?: number | null // Int
+    gte?: number | null // Int
+    in?: number[] | null // [Int!]
+    lt?: number | null // Int
+    lte?: number | null // Int
+    not?: NexusGenInputs['NestedIntFilter'] | null // NestedIntFilter
+    notIn?: number[] | null // [Int!]
   }
-  LocationCreateNestedOneWithoutUserInput: { // input type
-    connect?: NexusGenInputs['LocationWhereUniqueInput'] | null; // LocationWhereUniqueInput
-    connectOrCreate?: NexusGenInputs['LocationCreateOrConnectWithoutUserInput'] | null; // LocationCreateOrConnectWithoutUserInput
-    create?: NexusGenInputs['LocationCreateWithoutUserInput'] | null; // LocationCreateWithoutUserInput
+  LocationCreateNestedOneWithoutUserInput: {
+    // input type
+    connect?: NexusGenInputs['LocationWhereUniqueInput'] | null // LocationWhereUniqueInput
+    connectOrCreate?: NexusGenInputs['LocationCreateOrConnectWithoutUserInput'] | null // LocationCreateOrConnectWithoutUserInput
+    create?: NexusGenInputs['LocationCreateWithoutUserInput'] | null // LocationCreateWithoutUserInput
   }
-  LocationCreateOrConnectWithoutUserInput: { // input type
-    create: NexusGenInputs['LocationCreateWithoutUserInput']; // LocationCreateWithoutUserInput!
-    where: NexusGenInputs['LocationWhereUniqueInput']; // LocationWhereUniqueInput!
+  LocationCreateOrConnectWithoutUserInput: {
+    // input type
+    create: NexusGenInputs['LocationCreateWithoutUserInput'] // LocationCreateWithoutUserInput!
+    where: NexusGenInputs['LocationWhereUniqueInput'] // LocationWhereUniqueInput!
   }
-  LocationCreateWithoutUserInput: { // input type
-    city: string; // String!
-    country: string; // String!
+  LocationCreateWithoutUserInput: {
+    // input type
+    city: string // String!
+    country: string // String!
   }
-  LocationWhereInput: { // input type
-    AND?: NexusGenInputs['LocationWhereInput'][] | null; // [LocationWhereInput!]
-    city?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    country?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    id?: NexusGenInputs['IntFilter'] | null; // IntFilter
-    NOT?: NexusGenInputs['LocationWhereInput'][] | null; // [LocationWhereInput!]
-    OR?: NexusGenInputs['LocationWhereInput'][] | null; // [LocationWhereInput!]
-    User?: NexusGenInputs['UserListRelationFilter'] | null; // UserListRelationFilter
+  LocationWhereInput: {
+    // input type
+    AND?: NexusGenInputs['LocationWhereInput'][] | null // [LocationWhereInput!]
+    city?: NexusGenInputs['StringFilter'] | null // StringFilter
+    country?: NexusGenInputs['StringFilter'] | null // StringFilter
+    id?: NexusGenInputs['IntFilter'] | null // IntFilter
+    NOT?: NexusGenInputs['LocationWhereInput'][] | null // [LocationWhereInput!]
+    OR?: NexusGenInputs['LocationWhereInput'][] | null // [LocationWhereInput!]
+    User?: NexusGenInputs['UserListRelationFilter'] | null // UserListRelationFilter
   }
-  LocationWhereUniqueInput: { // input type
-    id?: number | null; // Int
+  LocationWhereUniqueInput: {
+    // input type
+    id?: number | null // Int
   }
-  NestedBoolFilter: { // input type
-    equals?: boolean | null; // Boolean
-    not?: NexusGenInputs['NestedBoolFilter'] | null; // NestedBoolFilter
+  NestedBoolFilter: {
+    // input type
+    equals?: boolean | null // Boolean
+    not?: NexusGenInputs['NestedBoolFilter'] | null // NestedBoolFilter
   }
-  NestedDateTimeFilter: { // input type
-    equals?: NexusGenScalars['DateTime'] | null; // DateTime
-    gt?: NexusGenScalars['DateTime'] | null; // DateTime
-    gte?: NexusGenScalars['DateTime'] | null; // DateTime
-    in?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
-    lt?: NexusGenScalars['DateTime'] | null; // DateTime
-    lte?: NexusGenScalars['DateTime'] | null; // DateTime
-    not?: NexusGenInputs['NestedDateTimeFilter'] | null; // NestedDateTimeFilter
-    notIn?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
+  NestedDateTimeFilter: {
+    // input type
+    equals?: NexusGenScalars['DateTime'] | null // DateTime
+    gt?: NexusGenScalars['DateTime'] | null // DateTime
+    gte?: NexusGenScalars['DateTime'] | null // DateTime
+    in?: NexusGenScalars['DateTime'][] | null // [DateTime!]
+    lt?: NexusGenScalars['DateTime'] | null // DateTime
+    lte?: NexusGenScalars['DateTime'] | null // DateTime
+    not?: NexusGenInputs['NestedDateTimeFilter'] | null // NestedDateTimeFilter
+    notIn?: NexusGenScalars['DateTime'][] | null // [DateTime!]
   }
-  NestedEnumPostStatusFilter: { // input type
-    equals?: NexusGenEnums['PostStatus'] | null; // PostStatus
-    in?: NexusGenEnums['PostStatus'][] | null; // [PostStatus!]
-    not?: NexusGenInputs['NestedEnumPostStatusFilter'] | null; // NestedEnumPostStatusFilter
-    notIn?: NexusGenEnums['PostStatus'][] | null; // [PostStatus!]
+  NestedEnumPostStatusFilter: {
+    // input type
+    equals?: NexusGenEnums['PostStatus'] | null // PostStatus
+    in?: NexusGenEnums['PostStatus'][] | null // [PostStatus!]
+    not?: NexusGenInputs['NestedEnumPostStatusFilter'] | null // NestedEnumPostStatusFilter
+    notIn?: NexusGenEnums['PostStatus'][] | null // [PostStatus!]
   }
-  NestedFloatFilter: { // input type
-    equals?: number | null; // Float
-    gt?: number | null; // Float
-    gte?: number | null; // Float
-    in?: number[] | null; // [Float!]
-    lt?: number | null; // Float
-    lte?: number | null; // Float
-    not?: NexusGenInputs['NestedFloatFilter'] | null; // NestedFloatFilter
-    notIn?: number[] | null; // [Float!]
+  NestedFloatFilter: {
+    // input type
+    equals?: number | null // Float
+    gt?: number | null // Float
+    gte?: number | null // Float
+    in?: number[] | null // [Float!]
+    lt?: number | null // Float
+    lte?: number | null // Float
+    not?: NexusGenInputs['NestedFloatFilter'] | null // NestedFloatFilter
+    notIn?: number[] | null // [Float!]
   }
-  NestedIntFilter: { // input type
-    equals?: number | null; // Int
-    gt?: number | null; // Int
-    gte?: number | null; // Int
-    in?: number[] | null; // [Int!]
-    lt?: number | null; // Int
-    lte?: number | null; // Int
-    not?: NexusGenInputs['NestedIntFilter'] | null; // NestedIntFilter
-    notIn?: number[] | null; // [Int!]
+  NestedIntFilter: {
+    // input type
+    equals?: number | null // Int
+    gt?: number | null // Int
+    gte?: number | null // Int
+    in?: number[] | null // [Int!]
+    lt?: number | null // Int
+    lte?: number | null // Int
+    not?: NexusGenInputs['NestedIntFilter'] | null // NestedIntFilter
+    notIn?: number[] | null // [Int!]
   }
-  NestedStringFilter: { // input type
-    contains?: string | null; // String
-    endsWith?: string | null; // String
-    equals?: string | null; // String
-    gt?: string | null; // String
-    gte?: string | null; // String
-    in?: string[] | null; // [String!]
-    lt?: string | null; // String
-    lte?: string | null; // String
-    not?: NexusGenInputs['NestedStringFilter'] | null; // NestedStringFilter
-    notIn?: string[] | null; // [String!]
-    startsWith?: string | null; // String
+  NestedStringFilter: {
+    // input type
+    contains?: string | null // String
+    endsWith?: string | null // String
+    equals?: string | null // String
+    gt?: string | null // String
+    gte?: string | null // String
+    in?: string[] | null // [String!]
+    lt?: string | null // String
+    lte?: string | null // String
+    not?: NexusGenInputs['NestedStringFilter'] | null // NestedStringFilter
+    notIn?: string[] | null // [String!]
+    startsWith?: string | null // String
   }
-  NestedStringNullableFilter: { // input type
-    contains?: string | null; // String
-    endsWith?: string | null; // String
-    equals?: string | null; // String
-    gt?: string | null; // String
-    gte?: string | null; // String
-    in?: string[] | null; // [String!]
-    lt?: string | null; // String
-    lte?: string | null; // String
-    not?: NexusGenInputs['NestedStringNullableFilter'] | null; // NestedStringNullableFilter
-    notIn?: string[] | null; // [String!]
-    startsWith?: string | null; // String
+  NestedStringNullableFilter: {
+    // input type
+    contains?: string | null // String
+    endsWith?: string | null // String
+    equals?: string | null // String
+    gt?: string | null // String
+    gte?: string | null // String
+    in?: string[] | null // [String!]
+    lt?: string | null // String
+    lte?: string | null // String
+    not?: NexusGenInputs['NestedStringNullableFilter'] | null // NestedStringNullableFilter
+    notIn?: string[] | null // [String!]
+    startsWith?: string | null // String
   }
-  PostCreateInput: { // input type
-    authors?: NexusGenInputs['UserCreateNestedManyWithoutPostsInput'] | null; // UserCreateNestedManyWithoutPostsInput
-    likes: number; // Int!
-    rating: number; // Float!
-    status: NexusGenEnums['PostStatus']; // PostStatus!
+  PostCreateInput: {
+    // input type
+    authors?: NexusGenInputs['UserCreateNestedManyWithoutPostsInput'] | null // UserCreateNestedManyWithoutPostsInput
+    likes: number // Int!
+    rating: number // Float!
+    status: NexusGenEnums['PostStatus'] // PostStatus!
   }
-  PostListRelationFilter: { // input type
-    every?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
-    none?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
-    some?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
+  PostListRelationFilter: {
+    // input type
+    every?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
+    none?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
+    some?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
   }
-  PostOrderByInput: { // input type
-    id?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    likes?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    rating?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    status?: NexusGenEnums['SortOrder'] | null; // SortOrder
+  PostOrderByInput: {
+    // input type
+    id?: NexusGenEnums['SortOrder'] | null // SortOrder
+    likes?: NexusGenEnums['SortOrder'] | null // SortOrder
+    rating?: NexusGenEnums['SortOrder'] | null // SortOrder
+    status?: NexusGenEnums['SortOrder'] | null // SortOrder
   }
-  PostUpdateManyMutationInput: { // input type
-    likes?: NexusGenInputs['IntFieldUpdateOperationsInput'] | null; // IntFieldUpdateOperationsInput
-    rating?: NexusGenInputs['FloatFieldUpdateOperationsInput'] | null; // FloatFieldUpdateOperationsInput
-    status?: NexusGenInputs['EnumPostStatusFieldUpdateOperationsInput'] | null; // EnumPostStatusFieldUpdateOperationsInput
+  PostUpdateManyMutationInput: {
+    // input type
+    likes?: NexusGenInputs['IntFieldUpdateOperationsInput'] | null // IntFieldUpdateOperationsInput
+    rating?: NexusGenInputs['FloatFieldUpdateOperationsInput'] | null // FloatFieldUpdateOperationsInput
+    status?: NexusGenInputs['EnumPostStatusFieldUpdateOperationsInput'] | null // EnumPostStatusFieldUpdateOperationsInput
   }
-  PostWhereInput: { // input type
-    AND?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
-    authors?: NexusGenInputs['UserListRelationFilter'] | null; // UserListRelationFilter
-    id?: NexusGenInputs['IntFilter'] | null; // IntFilter
-    likes?: NexusGenInputs['IntFilter'] | null; // IntFilter
-    NOT?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
-    OR?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
-    rating?: NexusGenInputs['FloatFilter'] | null; // FloatFilter
-    status?: NexusGenInputs['EnumPostStatusFilter'] | null; // EnumPostStatusFilter
+  PostWhereInput: {
+    // input type
+    AND?: NexusGenInputs['PostWhereInput'][] | null // [PostWhereInput!]
+    authors?: NexusGenInputs['UserListRelationFilter'] | null // UserListRelationFilter
+    id?: NexusGenInputs['IntFilter'] | null // IntFilter
+    likes?: NexusGenInputs['IntFilter'] | null // IntFilter
+    NOT?: NexusGenInputs['PostWhereInput'][] | null // [PostWhereInput!]
+    OR?: NexusGenInputs['PostWhereInput'][] | null // [PostWhereInput!]
+    rating?: NexusGenInputs['FloatFilter'] | null // FloatFilter
+    status?: NexusGenInputs['EnumPostStatusFilter'] | null // EnumPostStatusFilter
   }
-  PostWhereUniqueInput: { // input type
-    id?: number | null; // Int
+  PostWhereUniqueInput: {
+    // input type
+    id?: number | null // Int
   }
-  StringFilter: { // input type
-    contains?: string | null; // String
-    endsWith?: string | null; // String
-    equals?: string | null; // String
-    gt?: string | null; // String
-    gte?: string | null; // String
-    in?: string[] | null; // [String!]
-    lt?: string | null; // String
-    lte?: string | null; // String
-    mode?: NexusGenEnums['QueryMode'] | null; // QueryMode
-    not?: NexusGenInputs['NestedStringFilter'] | null; // NestedStringFilter
-    notIn?: string[] | null; // [String!]
-    startsWith?: string | null; // String
+  StringFilter: {
+    // input type
+    contains?: string | null // String
+    endsWith?: string | null // String
+    equals?: string | null // String
+    gt?: string | null // String
+    gte?: string | null // String
+    in?: string[] | null // [String!]
+    lt?: string | null // String
+    lte?: string | null // String
+    mode?: NexusGenEnums['QueryMode'] | null // QueryMode
+    not?: NexusGenInputs['NestedStringFilter'] | null // NestedStringFilter
+    notIn?: string[] | null // [String!]
+    startsWith?: string | null // String
   }
-  StringNullableFilter: { // input type
-    contains?: string | null; // String
-    endsWith?: string | null; // String
-    equals?: string | null; // String
-    gt?: string | null; // String
-    gte?: string | null; // String
-    in?: string[] | null; // [String!]
-    lt?: string | null; // String
-    lte?: string | null; // String
-    mode?: NexusGenEnums['QueryMode'] | null; // QueryMode
-    not?: NexusGenInputs['NestedStringNullableFilter'] | null; // NestedStringNullableFilter
-    notIn?: string[] | null; // [String!]
-    startsWith?: string | null; // String
+  StringNullableFilter: {
+    // input type
+    contains?: string | null // String
+    endsWith?: string | null // String
+    equals?: string | null // String
+    gt?: string | null // String
+    gte?: string | null // String
+    in?: string[] | null // [String!]
+    lt?: string | null // String
+    lte?: string | null // String
+    mode?: NexusGenEnums['QueryMode'] | null // QueryMode
+    not?: NexusGenInputs['NestedStringNullableFilter'] | null // NestedStringNullableFilter
+    notIn?: string[] | null // [String!]
+    startsWith?: string | null // String
   }
-  UserCreateNestedManyWithoutPostsInput: { // input type
-    connect?: NexusGenInputs['UserWhereUniqueInput'][] | null; // [UserWhereUniqueInput!]
-    connectOrCreate?: NexusGenInputs['UserCreateOrConnectWithoutPostsInput'][] | null; // [UserCreateOrConnectWithoutPostsInput!]
-    create?: NexusGenInputs['UserCreateWithoutPostsInput'][] | null; // [UserCreateWithoutPostsInput!]
+  UserCreateNestedManyWithoutPostsInput: {
+    // input type
+    connect?: NexusGenInputs['UserWhereUniqueInput'][] | null // [UserWhereUniqueInput!]
+    connectOrCreate?: NexusGenInputs['UserCreateOrConnectWithoutPostsInput'][] | null // [UserCreateOrConnectWithoutPostsInput!]
+    create?: NexusGenInputs['UserCreateWithoutPostsInput'][] | null // [UserCreateWithoutPostsInput!]
   }
-  UserCreateOrConnectWithoutPostsInput: { // input type
-    create: NexusGenInputs['UserCreateWithoutPostsInput']; // UserCreateWithoutPostsInput!
-    where: NexusGenInputs['UserWhereUniqueInput']; // UserWhereUniqueInput!
+  UserCreateOrConnectWithoutPostsInput: {
+    // input type
+    create: NexusGenInputs['UserCreateWithoutPostsInput'] // UserCreateWithoutPostsInput!
+    where: NexusGenInputs['UserWhereUniqueInput'] // UserWhereUniqueInput!
   }
-  UserCreateWithoutPostsInput: { // input type
-    Bubble?: NexusGenInputs['BubbleCreateNestedOneWithoutMembersInput'] | null; // BubbleCreateNestedOneWithoutMembersInput
-    firstName: string; // String!
-    id?: string | null; // String
-    lastName: string; // String!
-    location: NexusGenInputs['LocationCreateNestedOneWithoutUserInput']; // LocationCreateNestedOneWithoutUserInput!
+  UserCreateWithoutPostsInput: {
+    // input type
+    Bubble?: NexusGenInputs['BubbleCreateNestedOneWithoutMembersInput'] | null // BubbleCreateNestedOneWithoutMembersInput
+    firstName: string // String!
+    id?: string | null // String
+    lastName: string // String!
+    location: NexusGenInputs['LocationCreateNestedOneWithoutUserInput'] // LocationCreateNestedOneWithoutUserInput!
   }
-  UserListRelationFilter: { // input type
-    every?: NexusGenInputs['UserWhereInput'] | null; // UserWhereInput
-    none?: NexusGenInputs['UserWhereInput'] | null; // UserWhereInput
-    some?: NexusGenInputs['UserWhereInput'] | null; // UserWhereInput
+  UserListRelationFilter: {
+    // input type
+    every?: NexusGenInputs['UserWhereInput'] | null // UserWhereInput
+    none?: NexusGenInputs['UserWhereInput'] | null // UserWhereInput
+    some?: NexusGenInputs['UserWhereInput'] | null // UserWhereInput
   }
-  UserWhereInput: { // input type
-    AND?: NexusGenInputs['UserWhereInput'][] | null; // [UserWhereInput!]
-    Bubble?: NexusGenInputs['BubbleWhereInput'] | null; // BubbleWhereInput
-    bubbleId?: NexusGenInputs['StringNullableFilter'] | null; // StringNullableFilter
-    firstName?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    id?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    lastName?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    location?: NexusGenInputs['LocationWhereInput'] | null; // LocationWhereInput
-    locationId?: NexusGenInputs['IntFilter'] | null; // IntFilter
-    NOT?: NexusGenInputs['UserWhereInput'][] | null; // [UserWhereInput!]
-    OR?: NexusGenInputs['UserWhereInput'][] | null; // [UserWhereInput!]
-    posts?: NexusGenInputs['PostListRelationFilter'] | null; // PostListRelationFilter
+  UserWhereInput: {
+    // input type
+    AND?: NexusGenInputs['UserWhereInput'][] | null // [UserWhereInput!]
+    Bubble?: NexusGenInputs['BubbleWhereInput'] | null // BubbleWhereInput
+    bubbleId?: NexusGenInputs['StringNullableFilter'] | null // StringNullableFilter
+    firstName?: NexusGenInputs['StringFilter'] | null // StringFilter
+    id?: NexusGenInputs['StringFilter'] | null // StringFilter
+    lastName?: NexusGenInputs['StringFilter'] | null // StringFilter
+    location?: NexusGenInputs['LocationWhereInput'] | null // LocationWhereInput
+    locationId?: NexusGenInputs['IntFilter'] | null // IntFilter
+    NOT?: NexusGenInputs['UserWhereInput'][] | null // [UserWhereInput!]
+    OR?: NexusGenInputs['UserWhereInput'][] | null // [UserWhereInput!]
+    posts?: NexusGenInputs['PostListRelationFilter'] | null // PostListRelationFilter
   }
-  UserWhereUniqueInput: { // input type
-    id?: string | null; // String
+  UserWhereUniqueInput: {
+    // input type
+    id?: string | null // String
   }
 }
 
 export interface NexusGenEnums {
-  PostStatus: "DRAFT" | "PUBLISHED"
-  QueryMode: "default" | "insensitive"
-  SortOrder: "asc" | "desc"
+  PostStatus: 'DRAFT' | 'PUBLISHED'
+  QueryMode: 'default' | 'insensitive'
+  SortOrder: 'asc' | 'desc'
 }
 
 export interface NexusGenScalars {
@@ -319,103 +356,120 @@ export interface NexusGenScalars {
 }
 
 export interface NexusGenObjects {
-  AffectedRowsOutput: { // root type
-    count: number; // Int!
+  AffectedRowsOutput: {
+    // root type
+    count: number // Int!
   }
-  Bubble: { // root type
-    createdAt: NexusGenScalars['DateTime']; // DateTime!
-    id: string; // String!
+  Bubble: {
+    // root type
+    createdAt: NexusGenScalars['DateTime'] // DateTime!
+    id: string // String!
   }
-  Location: { // root type
-    city: string; // String!
-    country: string; // String!
-    id: number; // Int!
+  Location: {
+    // root type
+    city: string // String!
+    country: string // String!
+    id: number // Int!
   }
-  Mutation: {};
-  Post: { // root type
-    id: number; // Int!
-    status: NexusGenEnums['PostStatus']; // PostStatus!
+  Mutation: {}
+  Post: {
+    // root type
+    id: number // Int!
+    status: NexusGenEnums['PostStatus'] // PostStatus!
   }
-  Query: {};
-  User: { // root type
-    firstName: string; // String!
-    id: string; // String!
+  Query: {}
+  User: {
+    // root type
+    firstName: string // String!
+    id: string // String!
   }
 }
 
-export interface NexusGenInterfaces {
-}
+export interface NexusGenInterfaces {}
 
-export interface NexusGenUnions {
-}
+export interface NexusGenUnions {}
 
 export type NexusGenRootTypes = NexusGenObjects
 
 export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars & NexusGenEnums
 
 export interface NexusGenFieldTypes {
-  AffectedRowsOutput: { // field return type
-    count: number; // Int!
+  AffectedRowsOutput: {
+    // field return type
+    count: number // Int!
   }
-  Bubble: { // field return type
-    createdAt: NexusGenScalars['DateTime']; // DateTime!
-    id: string; // String!
-    members: NexusGenRootTypes['User'][]; // [User!]!
+  Bubble: {
+    // field return type
+    createdAt: NexusGenScalars['DateTime'] // DateTime!
+    id: string // String!
+    members: NexusGenRootTypes['User'][] // [User!]!
   }
-  Location: { // field return type
-    city: string; // String!
-    country: string; // String!
-    id: number; // Int!
+  Location: {
+    // field return type
+    city: string // String!
+    country: string // String!
+    id: number // Int!
   }
-  Mutation: { // field return type
-    createOnePost: NexusGenRootTypes['Post']; // Post!
-    updateManyPost: NexusGenRootTypes['AffectedRowsOutput']; // AffectedRowsOutput!
+  Mutation: {
+    // field return type
+    createOnePost: NexusGenRootTypes['Post'] // Post!
+    updateManyPost: NexusGenRootTypes['AffectedRowsOutput'] // AffectedRowsOutput!
   }
-  Post: { // field return type
-    authors: NexusGenRootTypes['User'][]; // [User!]!
-    id: number; // Int!
-    status: NexusGenEnums['PostStatus']; // PostStatus!
+  Post: {
+    // field return type
+    authors: NexusGenRootTypes['User'][] // [User!]!
+    id: number // Int!
+    status: NexusGenEnums['PostStatus'] // PostStatus!
   }
-  Query: { // field return type
-    user: NexusGenRootTypes['User'] | null; // User
-    users: NexusGenRootTypes['User'][]; // [User!]!
+  Query: {
+    // field return type
+    user: NexusGenRootTypes['User'] | null // User
+    users: NexusGenRootTypes['User'][] // [User!]!
   }
-  User: { // field return type
-    firstName: string; // String!
-    id: string; // String!
-    location: NexusGenRootTypes['Location']; // Location!
-    posts: NexusGenRootTypes['Post'][]; // [Post!]!
+  User: {
+    // field return type
+    firstName: string // String!
+    id: string // String!
+    location: NexusGenRootTypes['Location'] // Location!
+    posts: NexusGenRootTypes['Post'][] // [Post!]!
   }
 }
 
 export interface NexusGenFieldTypeNames {
-  AffectedRowsOutput: { // field return type name
+  AffectedRowsOutput: {
+    // field return type name
     count: 'Int'
   }
-  Bubble: { // field return type name
+  Bubble: {
+    // field return type name
     createdAt: 'DateTime'
     id: 'String'
     members: 'User'
   }
-  Location: { // field return type name
+  Location: {
+    // field return type name
     city: 'String'
     country: 'String'
     id: 'Int'
   }
-  Mutation: { // field return type name
+  Mutation: {
+    // field return type name
     createOnePost: 'Post'
     updateManyPost: 'AffectedRowsOutput'
   }
-  Post: { // field return type name
+  Post: {
+    // field return type name
     authors: 'User'
     id: 'Int'
     status: 'PostStatus'
   }
-  Query: { // field return type name
+  Query: {
+    // field return type name
     user: 'User'
     users: 'User'
   }
-  User: { // field return type name
+  User: {
+    // field return type name
     firstName: 'String'
     id: 'String'
     location: 'Location'
@@ -425,65 +479,69 @@ export interface NexusGenFieldTypeNames {
 
 export interface NexusGenArgTypes {
   Bubble: {
-    members: { // args
-      after?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
-      orderBy?: NexusGenInputs['BubbleMembersOrderByInput'][] | null; // [BubbleMembersOrderByInput!]
-      where?: NexusGenInputs['BubbleMembersWhereInput'] | null; // BubbleMembersWhereInput
+    members: {
+      // args
+      after?: NexusGenInputs['UserWhereUniqueInput'] | null // UserWhereUniqueInput
+      orderBy?: NexusGenInputs['BubbleMembersOrderByInput'][] | null // [BubbleMembersOrderByInput!]
+      where?: NexusGenInputs['BubbleMembersWhereInput'] | null // BubbleMembersWhereInput
     }
   }
   Mutation: {
-    createOnePost: { // args
-      data: NexusGenInputs['PostCreateInput']; // PostCreateInput!
+    createOnePost: {
+      // args
+      data: NexusGenInputs['PostCreateInput'] // PostCreateInput!
     }
-    updateManyPost: { // args
-      data: NexusGenInputs['PostUpdateManyMutationInput']; // PostUpdateManyMutationInput!
-      where?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
+    updateManyPost: {
+      // args
+      data: NexusGenInputs['PostUpdateManyMutationInput'] // PostUpdateManyMutationInput!
+      where?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
     }
   }
   Query: {
-    user: { // args
-      where: NexusGenInputs['UserWhereUniqueInput']; // UserWhereUniqueInput!
+    user: {
+      // args
+      where: NexusGenInputs['UserWhereUniqueInput'] // UserWhereUniqueInput!
     }
-    users: { // args
-      after?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
-      before?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
-      first?: number | null; // Int
-      last?: number | null; // Int
+    users: {
+      // args
+      after?: NexusGenInputs['UserWhereUniqueInput'] | null // UserWhereUniqueInput
+      before?: NexusGenInputs['UserWhereUniqueInput'] | null // UserWhereUniqueInput
+      first?: number | null // Int
+      last?: number | null // Int
     }
   }
   User: {
-    posts: { // args
-      after?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
-      before?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
-      first?: number | null; // Int
-      last?: number | null; // Int
-      orderBy?: NexusGenInputs['PostOrderByInput'][] | null; // [PostOrderByInput!]
-      where?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
+    posts: {
+      // args
+      after?: NexusGenInputs['PostWhereUniqueInput'] | null // PostWhereUniqueInput
+      before?: NexusGenInputs['PostWhereUniqueInput'] | null // PostWhereUniqueInput
+      first?: number | null // Int
+      last?: number | null // Int
+      orderBy?: NexusGenInputs['PostOrderByInput'][] | null // [PostOrderByInput!]
+      where?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
     }
   }
 }
 
-export interface NexusGenAbstractTypeMembers {
-}
+export interface NexusGenAbstractTypeMembers {}
 
-export interface NexusGenTypeInterfaces {
-}
+export interface NexusGenTypeInterfaces {}
 
-export type NexusGenObjectNames = keyof NexusGenObjects;
+export type NexusGenObjectNames = keyof NexusGenObjects
 
-export type NexusGenInputNames = keyof NexusGenInputs;
+export type NexusGenInputNames = keyof NexusGenInputs
 
-export type NexusGenEnumNames = keyof NexusGenEnums;
+export type NexusGenEnumNames = keyof NexusGenEnums
 
-export type NexusGenInterfaceNames = never;
+export type NexusGenInterfaceNames = never
 
-export type NexusGenScalarNames = keyof NexusGenScalars;
+export type NexusGenScalarNames = keyof NexusGenScalars
 
-export type NexusGenUnionNames = never;
+export type NexusGenUnionNames = never
 
-export type NexusGenObjectsUsingAbstractStrategyIsTypeOf = never;
+export type NexusGenObjectsUsingAbstractStrategyIsTypeOf = never
 
-export type NexusGenAbstractsUsingStrategyResolveType = never;
+export type NexusGenAbstractsUsingStrategyResolveType = never
 
 export type NexusGenFeaturesConfig = {
   abstractTypeStrategies: {
@@ -494,41 +552,40 @@ export type NexusGenFeaturesConfig = {
 }
 
 export interface NexusGenTypes {
-  context: any;
-  inputTypes: NexusGenInputs;
-  rootTypes: NexusGenRootTypes;
-  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars;
-  argTypes: NexusGenArgTypes;
-  fieldTypes: NexusGenFieldTypes;
-  fieldTypeNames: NexusGenFieldTypeNames;
-  allTypes: NexusGenAllTypes;
-  typeInterfaces: NexusGenTypeInterfaces;
-  objectNames: NexusGenObjectNames;
-  inputNames: NexusGenInputNames;
-  enumNames: NexusGenEnumNames;
-  interfaceNames: NexusGenInterfaceNames;
-  scalarNames: NexusGenScalarNames;
-  unionNames: NexusGenUnionNames;
-  allInputTypes: NexusGenTypes['inputNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['scalarNames'];
-  allOutputTypes: NexusGenTypes['objectNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['unionNames'] | NexusGenTypes['interfaceNames'] | NexusGenTypes['scalarNames'];
+  context: any
+  inputTypes: NexusGenInputs
+  rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
+  argTypes: NexusGenArgTypes
+  fieldTypes: NexusGenFieldTypes
+  fieldTypeNames: NexusGenFieldTypeNames
+  allTypes: NexusGenAllTypes
+  typeInterfaces: NexusGenTypeInterfaces
+  objectNames: NexusGenObjectNames
+  inputNames: NexusGenInputNames
+  enumNames: NexusGenEnumNames
+  interfaceNames: NexusGenInterfaceNames
+  scalarNames: NexusGenScalarNames
+  unionNames: NexusGenUnionNames
+  allInputTypes: NexusGenTypes['inputNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['scalarNames']
+  allOutputTypes:
+    | NexusGenTypes['objectNames']
+    | NexusGenTypes['enumNames']
+    | NexusGenTypes['unionNames']
+    | NexusGenTypes['interfaceNames']
+    | NexusGenTypes['scalarNames']
   allNamedTypes: NexusGenTypes['allInputTypes'] | NexusGenTypes['allOutputTypes']
-  abstractTypes: NexusGenTypes['interfaceNames'] | NexusGenTypes['unionNames'];
-  abstractTypeMembers: NexusGenAbstractTypeMembers;
-  objectsUsingAbstractStrategyIsTypeOf: NexusGenObjectsUsingAbstractStrategyIsTypeOf;
-  abstractsUsingStrategyResolveType: NexusGenAbstractsUsingStrategyResolveType;
-  features: NexusGenFeaturesConfig;
+  abstractTypes: NexusGenTypes['interfaceNames'] | NexusGenTypes['unionNames']
+  abstractTypeMembers: NexusGenAbstractTypeMembers
+  objectsUsingAbstractStrategyIsTypeOf: NexusGenObjectsUsingAbstractStrategyIsTypeOf
+  abstractsUsingStrategyResolveType: NexusGenAbstractsUsingStrategyResolveType
+  features: NexusGenFeaturesConfig
 }
 
-
 declare global {
-  interface NexusGenPluginTypeConfig<TypeName extends string> {
-  }
-  interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
-  }
-  interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {
-  }
-  interface NexusGenPluginSchemaConfig {
-  }
-  interface NexusGenPluginArgConfig {
-  }
+  interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
+  interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
+  interface NexusGenPluginSchemaConfig {}
+  interface NexusGenPluginArgConfig {}
 }

--- a/tests/__client-test-context.ts
+++ b/tests/__client-test-context.ts
@@ -48,9 +48,7 @@ export function createRuntimeTestContext(): RuntimeTestContext {
     async setup({ datamodel, types, plugins, scalars }) {
       try {
         const metadata = getTestMetadata(datamodel)
-
         await fs.dirAsync(metadata.tmpDir)
-
         const prismaClient = await generateClientFromDatamodel(metadata)
         generatedClient = prismaClient
 

--- a/tests/schema/__snapshots__/computedWhereInputs.test.ts.snap
+++ b/tests/schema/__snapshots__/computedWhereInputs.test.ts.snap
@@ -1,0 +1,298 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`removes global computedWhereInputs from all input types: globallyComputedWhereInputs 1`] = `
+Object {
+  "schema": "type Query {
+  user(where: UserWhereUniqueInput!): User
+  users(first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput): [User!]!
+}
+
+type Mutation {
+  createOneUser(data: UserCreateInput!): User!
+  createOneNested(data: NestedCreateInput!): Nested!
+}
+
+type User {
+  id: Int!
+  name: String!
+  nested(first: Int, last: Int, before: NestedWhereUniqueInput, after: NestedWhereUniqueInput): [Nested!]!
+  createdWithBrowser: String!
+}
+
+type Nested {
+  id: Int!
+  createdWithBrowser: String!
+  name: String!
+}
+
+input UserWhereUniqueInput {
+  id: Int
+}
+
+input UserCreateInput {
+  organizationId: Int!
+  name: String!
+  createdWithBrowser: String!
+  nested: NestedCreateNestedManyWithoutUserInput
+}
+
+input NestedCreateInput {
+  name: String!
+  createdWithBrowser: String!
+  user: UserCreateNestedOneWithoutNestedInput!
+}
+
+input NestedWhereUniqueInput {
+  id: Int
+}
+
+input NestedCreateNestedManyWithoutUserInput {
+  create: [NestedCreateWithoutUserInput!]
+  connectOrCreate: [NestedCreateOrConnectWithoutUserInput!]
+  connect: [NestedWhereUniqueInput!]
+}
+
+input UserCreateNestedOneWithoutNestedInput {
+  create: UserCreateWithoutNestedInput
+  connectOrCreate: UserCreateOrConnectWithoutNestedInput
+  connect: UserWhereUniqueInput
+}
+
+input NestedCreateWithoutUserInput {
+  name: String!
+  createdWithBrowser: String!
+}
+
+input NestedCreateOrConnectWithoutUserInput {
+  where: NestedWhereUniqueInput!
+  create: NestedCreateWithoutUserInput!
+}
+
+input UserCreateWithoutNestedInput {
+  organizationId: Int!
+  name: String!
+  createdWithBrowser: String!
+}
+
+input UserCreateOrConnectWithoutNestedInput {
+  where: UserWhereUniqueInput!
+  create: UserCreateWithoutNestedInput!
+}
+",
+  "typegen": "import * as Typegen from 'nexus-plugin-prisma/typegen'
+import * as Prisma from '@prisma/client';
+
+// Pagination type
+type Pagination = {
+    first?: boolean
+    last?: boolean
+    before?: boolean
+    after?: boolean
+}
+
+// Prisma custom scalar names
+type CustomScalars = 'No custom scalars are used in your Prisma Schema.'
+
+// Prisma model type definitions
+interface PrismaModels {
+  User: Prisma.User
+  Nested: Prisma.Nested
+}
+
+// Prisma input types metadata
+interface NexusPrismaInputs {
+  Query: {
+    users: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'organizationId' | 'name' | 'nested' | 'createdWithBrowser'
+      ordering: 'id' | 'organizationId' | 'name' | 'createdWithBrowser'
+    }
+    nesteds: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'name' | 'createdWithBrowser' | 'userId' | 'user'
+      ordering: 'id' | 'name' | 'createdWithBrowser' | 'userId'
+    }
+  },
+  User: {
+    nested: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'name' | 'createdWithBrowser' | 'userId' | 'user'
+      ordering: 'id' | 'name' | 'createdWithBrowser' | 'userId'
+    }
+  }
+  Nested: {
+
+  }
+}
+
+// Prisma output types metadata
+interface NexusPrismaOutputs {
+  Query: {
+    user: 'User'
+    users: 'User'
+    nested: 'Nested'
+    nesteds: 'Nested'
+  },
+  Mutation: {
+    createOneUser: 'User'
+    updateOneUser: 'User'
+    updateManyUser: 'AffectedRowsOutput'
+    deleteOneUser: 'User'
+    deleteManyUser: 'AffectedRowsOutput'
+    upsertOneUser: 'User'
+    createOneNested: 'Nested'
+    updateOneNested: 'Nested'
+    updateManyNested: 'AffectedRowsOutput'
+    deleteOneNested: 'Nested'
+    deleteManyNested: 'AffectedRowsOutput'
+    upsertOneNested: 'Nested'
+  },
+  User: {
+    id: 'Int'
+    organizationId: 'Int'
+    name: 'String'
+    nested: 'Nested'
+    createdWithBrowser: 'String'
+  }
+  Nested: {
+    id: 'Int'
+    name: 'String'
+    createdWithBrowser: 'String'
+    userId: 'Int'
+    user: 'User'
+  }
+}
+
+// Helper to gather all methods relative to a model
+interface NexusPrismaMethods {
+  User: Typegen.NexusPrismaFields<'User'>
+  Nested: Typegen.NexusPrismaFields<'Nested'>
+  Query: Typegen.NexusPrismaFields<'Query'>
+  Mutation: Typegen.NexusPrismaFields<'Mutation'>
+}
+
+interface NexusPrismaGenTypes {
+  inputs: NexusPrismaInputs
+  outputs: NexusPrismaOutputs
+  methods: NexusPrismaMethods
+  models: PrismaModels
+  pagination: Pagination
+  scalars: CustomScalars
+}
+
+declare global {
+  interface NexusPrismaGen extends NexusPrismaGenTypes {}
+
+  type NexusPrisma<
+    TypeName extends string,
+    ModelOrCrud extends 'model' | 'crud'
+  > = Typegen.GetNexusPrisma<TypeName, ModelOrCrud>;
+}
+  ",
+}
+`;
+
+exports[`removes resolver-level computedWhereInputs from the corresponding input type: locallyComputedWhereInputs 1`] = `
+Object {
+  "schema": "type Query {
+  user(where: UserWhereUniqueInput!): User
+  users(first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput): [User!]!
+}
+
+type Mutation {
+  createOneUser(data: UserCreateInput!): User!
+}
+
+type User {
+  id: Int!
+  name: String!
+  createdWithBrowser: String!
+}
+
+input UserWhereUniqueInput {
+  id: Int
+}
+
+input UserCreateInput {
+  organizationId: Int!
+  name: String!
+}
+",
+  "typegen": "import * as Typegen from 'nexus-plugin-prisma/typegen'
+import * as Prisma from '@prisma/client';
+
+// Pagination type
+type Pagination = {
+    first?: boolean
+    last?: boolean
+    before?: boolean
+    after?: boolean
+}
+
+// Prisma custom scalar names
+type CustomScalars = 'No custom scalars are used in your Prisma Schema.'
+
+// Prisma model type definitions
+interface PrismaModels {
+  User: Prisma.User
+}
+
+// Prisma input types metadata
+interface NexusPrismaInputs {
+  Query: {
+    users: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'organizationId' | 'name' | 'createdWithBrowser'
+      ordering: 'id' | 'organizationId' | 'name' | 'createdWithBrowser'
+    }
+  },
+  User: {
+
+  }
+}
+
+// Prisma output types metadata
+interface NexusPrismaOutputs {
+  Query: {
+    user: 'User'
+    users: 'User'
+  },
+  Mutation: {
+    createOneUser: 'User'
+    updateOneUser: 'User'
+    updateManyUser: 'AffectedRowsOutput'
+    deleteOneUser: 'User'
+    deleteManyUser: 'AffectedRowsOutput'
+    upsertOneUser: 'User'
+  },
+  User: {
+    id: 'Int'
+    organizationId: 'Int'
+    name: 'String'
+    createdWithBrowser: 'String'
+  }
+}
+
+// Helper to gather all methods relative to a model
+interface NexusPrismaMethods {
+  User: Typegen.NexusPrismaFields<'User'>
+  Query: Typegen.NexusPrismaFields<'Query'>
+  Mutation: Typegen.NexusPrismaFields<'Mutation'>
+}
+
+interface NexusPrismaGenTypes {
+  inputs: NexusPrismaInputs
+  outputs: NexusPrismaOutputs
+  methods: NexusPrismaMethods
+  models: PrismaModels
+  pagination: Pagination
+  scalars: CustomScalars
+}
+
+declare global {
+  interface NexusPrismaGen extends NexusPrismaGenTypes {}
+
+  type NexusPrisma<
+    TypeName extends string,
+    ModelOrCrud extends 'model' | 'crud'
+  > = Typegen.GetNexusPrisma<TypeName, ModelOrCrud>;
+}
+  ",
+}
+`;

--- a/tests/schema/__snapshots__/computedWhereInputs.test.ts.snap
+++ b/tests/schema/__snapshots__/computedWhereInputs.test.ts.snap
@@ -30,7 +30,6 @@ input UserWhereUniqueInput {
 }
 
 input UserCreateInput {
-  organizationId: Int!
   name: String!
   createdWithBrowser: String!
   nested: NestedCreateNestedManyWithoutUserInput
@@ -69,7 +68,6 @@ input NestedCreateOrConnectWithoutUserInput {
 }
 
 input UserCreateWithoutNestedInput {
-  organizationId: Int!
   name: String!
   createdWithBrowser: String!
 }
@@ -103,8 +101,8 @@ interface PrismaModels {
 interface NexusPrismaInputs {
   Query: {
     users: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'organizationId' | 'name' | 'nested' | 'createdWithBrowser'
-      ordering: 'id' | 'organizationId' | 'name' | 'createdWithBrowser'
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'name' | 'nested' | 'createdWithBrowser'
+      ordering: 'id' | 'name' | 'createdWithBrowser'
     }
     nesteds: {
       filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'name' | 'createdWithBrowser' | 'userId' | 'user'
@@ -193,7 +191,7 @@ exports[`removes resolver-level computedWhereInputs from the corresponding input
 Object {
   "schema": "type Query {
   user(where: UserWhereUniqueInput!): User
-  users(first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput): [User!]!
+  users(where: QueryUsersWhereInput, first: Int, last: Int, before: UserWhereUniqueInput, after: UserWhereUniqueInput): [User!]!
 }
 
 type Mutation {
@@ -210,9 +208,42 @@ input UserWhereUniqueInput {
   id: Int
 }
 
+input QueryUsersWhereInput {
+  createdWithBrowser: StringFilter
+}
+
 input UserCreateInput {
   organizationId: Int!
   name: String!
+  createdWithBrowser: String!
+}
+
+input StringFilter {
+  equals: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  not: NestedStringFilter
+}
+
+input NestedStringFilter {
+  equals: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  not: NestedStringFilter
 }
 ",
   "typegen": "import * as Typegen from 'nexus-plugin-prisma/typegen'

--- a/tests/schema/computedWhereInputs.test.ts
+++ b/tests/schema/computedWhereInputs.test.ts
@@ -1,0 +1,522 @@
+import * as Nexus from 'nexus'
+import { addComputedInputs, addComputedWhereInputs } from '../../src/dmmf/transformer'
+import { GlobalComputedInputs, GlobalComputedWhereInputs } from '../../src/utils'
+import { generateSchemaAndTypes, getDmmf } from '../__utils'
+
+// TODO: Split local and global computedInputs into their own suites
+
+const resolverTestData = {
+  datamodel: `
+  model User {
+    id  Int @id @default(autoincrement())
+    organizationId Int
+    name String
+    createdWithBrowser String
+  }
+`,
+  query: Nexus.queryType({
+    definition(t: any) {
+      t.crud.user()
+      t.crud.users({
+        computedWhereInputs: {
+          organizationId: ({ ctx }) => ctx.organizationId,
+        } as GlobalComputedWhereInputs,
+      })
+    },
+  }),
+  mutation: Nexus.mutationType({
+    definition(t: any) {
+      t.crud.createOneUser({
+        computedInputs: {
+          createdWithBrowser: ({ ctx }) => ctx.browser,
+        } as GlobalComputedInputs,
+      })
+    },
+  }),
+  user: Nexus.objectType({
+    name: 'User',
+    definition: (t: any) => {
+      t.model.id()
+      t.model.name()
+      t.model.createdWithBrowser()
+    },
+  }),
+}
+
+const globalTestData = {
+  datamodel: `
+  model User {
+    id  Int @id @default(autoincrement())
+    organizationId Int
+    name String
+    nested Nested[]
+    createdWithBrowser String
+  }
+
+  model Nested {
+    id Int @id @default(autoincrement())
+    name String
+    createdWithBrowser String
+    userId Int
+    user User @relation(fields: [userId], references: [id])
+  }
+`,
+  query: Nexus.queryType({
+    definition(t: any) {
+      t.crud.user()
+      t.crud.users()
+    },
+  }),
+  mutation: Nexus.mutationType({
+    definition(t: any) {
+      t.crud.createOneUser()
+      t.crud.createOneNested()
+    },
+  }),
+  user: Nexus.objectType({
+    name: 'User',
+    definition: (t: any) => {
+      t.model.id()
+      t.model.name()
+      t.model.nested()
+      t.model.createdWithBrowser()
+    },
+  }),
+  nested: Nexus.objectType({
+    name: 'Nested',
+    definition: (t: any) => {
+      t.model.id()
+      t.model.createdWithBrowser()
+      t.model.name()
+    },
+  }),
+}
+
+it('removes resolver-level computedWhereInputs from the corresponding input type', async () => {
+  const { datamodel, ...resolvers } = resolverTestData
+  const result = await generateSchemaAndTypes(datamodel, Object.values(resolvers))
+
+  expect({
+    schema: result.schemaString,
+    typegen: result.typegen,
+  }).toMatchSnapshot('locallyComputedWhereInputs')
+})
+
+it('infers the value of resolver-level computedWhereInputs at runtime', async () => {
+  const { datamodel } = resolverTestData
+  const dmmf = await getDmmf(datamodel)
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        info: {} as any,
+        args: {},
+        ctx: { organizationId: 1 },
+      },
+      argType: 'UserWhereInput',
+      inputType: dmmf.getInputType('UserWhereInput'),
+      dmmf,
+      locallyComputedWhereInputs: {
+        organizationId: ({ ctx }) => ({ equals: ctx.organizationId }),
+      },
+    })
+  ).toStrictEqual({ where: { organizationId: { equals: 1 } } })
+})
+
+it('removes global computedWhereInputs from all input types', async () => {
+  const { datamodel, ...resolvers } = globalTestData
+  const result = await generateSchemaAndTypes(datamodel, Object.values(resolvers), {
+    globallyComputedWhereInputs: { organizationId: ({ ctx }) => ({ equals: ctx.organizationId }) },
+  })
+
+  expect({
+    schema: result.schemaString,
+    typegen: result.typegen,
+  }).toMatchSnapshot('globallyComputedWhereInputs')
+})
+
+it('infers the value of global computedWhereInputs at runtime', async () => {
+  const { datamodel } = globalTestData
+  const dmmf = await getDmmf(datamodel, {
+    globallyComputedWhereInputs: { id: ({ ctx }) => ({ equals: ctx.organizationId }) },
+  })
+
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        info: {} as any,
+        args: {
+          where: {
+            id: 1,
+          },
+        },
+        ctx: { organizationId: 1 },
+      },
+      argType: 'UserWhereUniqueInput',
+      inputType: dmmf.getInputType('UserWhereUniqueInput'),
+      dmmf,
+      locallyComputedWhereInputs: {},
+    })
+  ).toStrictEqual({
+    where: {
+      id: 1,
+    },
+  })
+})
+
+it('does not add the value to args whose schema does not have key.', async () => {
+  const { datamodel } = globalTestData
+  const dmmf = await getDmmf(datamodel, {
+    globallyComputedWhereInputs: { organizationId: ({ ctx }) => ({ equals: ctx.organizationId }) },
+  })
+
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        info: {} as any,
+        args: {
+          where: {
+            name: { contains: 'a' },
+            nested: {
+              some: {
+                name: {
+                  contains: 'a',
+                },
+              },
+            },
+          },
+        },
+        ctx: { organizationId: 1 },
+      },
+      argType: 'UserWhereInput',
+      inputType: dmmf.getInputType('UserWhereInput'),
+      dmmf,
+      locallyComputedWhereInputs: {},
+    })
+  ).toStrictEqual({
+    where: {
+      name: {
+        contains: 'a',
+      },
+      organizationId: { equals: 1 },
+      nested: {
+        some: {
+          name: {
+            contains: 'a',
+          },
+        },
+      },
+    },
+  })
+})
+
+it('infers the value of global computedWhereInputs at runtime and override original args that has same key', async () => {
+  const { datamodel } = globalTestData
+  const dmmf = await getDmmf(datamodel, {
+    globallyComputedWhereInputs: { organizationId: ({ ctx }) => ({ equals: ctx.organizationId }) },
+  })
+
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        info: {} as any,
+        args: {
+          where: {
+            organizationId: { equals: 2 }, // If args specified some value with the same key. It should override by computedInput
+            name: { contains: 'a' },
+            nested: {
+              some: {
+                name: {
+                  contains: 'a',
+                },
+              },
+            },
+          },
+        },
+        ctx: { organizationId: 1 },
+      },
+      argType: 'UserWhereInput',
+      inputType: dmmf.getInputType('UserWhereInput'),
+      dmmf,
+      locallyComputedWhereInputs: {},
+    })
+  ).toStrictEqual({
+    where: {
+      name: {
+        contains: 'a',
+      },
+      organizationId: { equals: 1 },
+      nested: {
+        some: {
+          name: {
+            contains: 'a',
+          },
+        },
+      },
+    },
+  })
+})
+
+it('infers the nested value of global computedInputs at runtime', async () => {
+  const { datamodel } = globalTestData
+  const dmmf = await getDmmf(datamodel, {
+    globallyComputedWhereInputs: { nested: ({ ctx }) => ({ some: { name: { contains: ctx.contains } } }) },
+  })
+
+  // console.log(JSON.stringify(dmmf.getInputType('NestedWhereInput'),null,1))
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        info: {} as any,
+        args: {
+          where: {
+            name: {
+              contains: 'a',
+            },
+          },
+        },
+        ctx: { contains: 'a' },
+      },
+      argType: 'UserWhereInput',
+      inputType: dmmf.getInputType('UserWhereInput'),
+      dmmf,
+      locallyComputedWhereInputs: {},
+    })
+  ).toStrictEqual({
+    where: {
+      name: {
+        contains: 'a',
+      },
+      nested: {
+        some: {
+          name: {
+            contains: 'a',
+          },
+        },
+      },
+    },
+  })
+})
+
+it('override original args that has same key with the nested global computed input', async () => {
+  const { datamodel } = globalTestData
+  const dmmf = await getDmmf(datamodel, {
+    globallyComputedWhereInputs: { nested: ({ ctx }) => ({ some: { name: { contains: 'a' } } }) },
+  })
+
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        info: {} as any,
+        args: {
+          where: {
+            name: {
+              contains: 'a',
+            },
+            nested: {
+              every: {
+                name: {
+                  contains: 'b',
+                },
+              },
+            },
+          },
+        },
+        ctx: { organizationId: 1 },
+      },
+      argType: 'UserWhereInput',
+      inputType: dmmf.getInputType('UserWhereInput'),
+      dmmf,
+      locallyComputedWhereInputs: {},
+    })
+  ).toStrictEqual({
+    where: {
+      name: {
+        contains: 'a',
+      },
+      nested: {
+        some: {
+          name: {
+            contains: 'a',
+          },
+        },
+      },
+    },
+  })
+})
+
+it('override original all nested args that has same key with global computed inputs.', async () => {
+  const { datamodel } = globalTestData
+  const dmmf = await getDmmf(datamodel, {
+    globallyComputedWhereInputs: { name: () => ({ contains: 'c' }) },
+  })
+
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        info: {} as any,
+        args: {
+          where: {
+            name: {
+              contains: 'a',
+            },
+            nested: {
+              some: {
+                name: {
+                  contains: 'b',
+                },
+              },
+            },
+          },
+        },
+        ctx: { organizationId: 1 },
+      },
+      argType: 'UserWhereInput',
+      inputType: dmmf.getInputType('UserWhereInput'),
+      dmmf,
+      locallyComputedWhereInputs: {},
+    })
+  ).toStrictEqual({
+    where: {
+      name: {
+        contains: 'c',
+      },
+      nested: {
+        some: {
+          name: {
+            contains: 'c',
+          },
+        },
+      },
+    },
+  })
+})
+
+it('can combine resolver-level (shallow) and global (deep) computed where inputs', async () => {
+  const { datamodel } = globalTestData
+  const dmmf = await getDmmf(datamodel, {
+    // These are applied globally
+    globallyComputedWhereInputs: { createdWithBrowser: ({ ctx }) => ctx.browser },
+  })
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        info: {} as any,
+        // name should be required when querying Nested since the computedWhereInput providing
+        // it is specific to UserWhereInput and therefore shallow
+        args: {
+          where: {
+            nested: {
+              some: {
+                name: {
+                  contains: 'b',
+                },
+              },
+            },
+          },
+        },
+        ctx: { browser: 'firefox', name: 'autopopulated' },
+      },
+      argType: 'UserWhereInput',
+      inputType: dmmf.getInputType('UserWhereInput'),
+      dmmf,
+      // These are applied only to UserWhereInput
+      locallyComputedWhereInputs: { name: ({ ctx }) => ctx.name },
+    })
+  ).toStrictEqual({
+    where: {
+      name: 'autopopulated',
+      createdWithBrowser: 'firefox',
+      nested: {
+        some: {
+          createdWithBrowser: 'firefox',
+          name: {
+            contains: 'b',
+          },
+        },
+      },
+    },
+  })
+})
+
+it('can use a combination of args, context and info to compute values', async () => {
+  const { datamodel } = globalTestData
+  // Nonsense example, but ensures args, ctx and info values are being passed everywhere :)
+  const dmmf = await getDmmf(datamodel, {
+    globallyComputedWhereInputs: {
+      createdWithBrowser: ({ args, ctx, info }) =>
+        `${ctx.browser.slice(1, 2)} ${info} ${(args.where as any).nested.some.name}`,
+    },
+  })
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        // Normally this would be GraphQLResolveInfo but using a string for simplicity
+        info: 'Yam' as any,
+        args: { where: { nested: { some: { name: 'Sam' } } } },
+        ctx: { browser: 'firefox' },
+      },
+      inputType: dmmf.getInputType('UserWhereInput'),
+      dmmf,
+      argType: 'UserWhereInput',
+      locallyComputedWhereInputs: {
+        name: ({ args, ctx, info }) => `${args.where.nested.some.name} ${ctx.browser.slice(1, 2)} ${info}`,
+      },
+    })
+  ).toStrictEqual({
+    where: {
+      name: 'Sam i Yam',
+      createdWithBrowser: 'i Yam Sam',
+      nested: {
+        some: { createdWithBrowser: 'i Yam Sam', name: 'Sam' },
+      },
+    },
+  })
+})
+
+it('supports async functions on both global and local computed where input', async () => {
+  const { datamodel } = globalTestData
+  const dmmf = await getDmmf(datamodel, {
+    // These are applied globally
+    globallyComputedWhereInputs: {
+      createdWithBrowser: async ({ ctx }) => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(ctx.browser)
+          }, 0)
+        })
+      },
+    },
+  })
+  expect(
+    await addComputedWhereInputs({
+      params: {
+        info: {} as any,
+        // name should be required when creating Nested since the computedInput providing
+        // it is specific to UserCreateInput and therefore shallow
+        args: { where: { nested: { some: { name: 'Nested Name' } } } },
+        ctx: { browser: 'firefox', name: 'autopopulated' },
+      },
+      inputType: dmmf.getInputType('UserWhereInput'),
+      argType: 'UserWhereInput',
+      dmmf,
+      // These are applied only to UserCreateInput
+      locallyComputedWhereInputs: {
+        name: async ({ ctx }) => {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(ctx.name)
+            }, 0)
+          })
+        },
+      },
+    })
+  ).toStrictEqual({
+    where: {
+      name: 'autopopulated',
+      createdWithBrowser: 'firefox',
+      nested: {
+        some: { createdWithBrowser: 'firefox', name: 'Nested Name' },
+      },
+    },
+  })
+})


### PR DESCRIPTION
# Overview
I add computeWhereInput to crud and global setting like computedInput.
- It add args to "where input" when you query models and the model has the same key of computeWhereInput.
- It can be defined globally and locally.
- When filtering option is "true". It remove computedWhereInput from the corresponding where input type.



# Why
I want to use computedInput in my query.
For example, let's say "User" has "Posts" and user can query only his own "Posts", I think it's currently possible with FieldAuthorize plugin and filtering options.

But ideally, it would be nice to write the following and have it automatically filtered.
in schema.ts.
```typescript
 nexusPrisma({
      experimentalCRUD: true,
      computedWhereInputs: {
        userId: ({ ctx }) => {
          if (!ctx.user.id) {
            throw Error("Not Authorized");
          }
          return { equals: ctx.user.id };
        },
      },
    }),
```

in Query defintion.
```typescript
 t.crud.posts();
```

This is reported in https://github.com/graphql-nexus/nexus/issues/902

# Changes
- Add ComputedWhereInput types  to builder.ts and transformar.ts
- Add Condition for executing addComputedWhereInput()
- Add a test using  with reference to computedInput.test.ts.

# Notes
- I thought I could do "select" input and "ordering" input in the same way, but once I implemented "where" input, since computedInput was also limited to Mutation "data" input.
- I know you're working on migrating this repository, but I send you a PR because I've used this feature on two projects and found it very useful.