### PR TITLE
fix: Make addComputedInputs work when data is undefined

### DIFF
--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -222,6 +222,7 @@ async function addGloballyComputedInputs({
     }),
     Promise.resolve({} as Record<string, any>)
   )
+
   // Combine computedInputValues with values provided by the user, recursing to add
   // global computedInputs to nested types
   return Object.keys(data).reduce(async (deeplyComputedData, fieldName) => {
@@ -248,6 +249,10 @@ export async function addComputedInputs({
   locallyComputedInputs,
   params,
 }: AddComputedInputParams) {
+  if (params.args.data === undefined) {
+    return { ...params.args }
+  }
+
   return {
     ...params.args,
     data: {

--- a/tests/schema/__snapshots__/computedInputs.test.ts.snap
+++ b/tests/schema/__snapshots__/computedInputs.test.ts.snap
@@ -7,6 +7,7 @@ Object {
 }
 
 type Mutation {
+  deleteOneUser(where: UserWhereUniqueInput!): User
   createOneUser(data: UserCreateInput!): User!
   createOneNested(data: NestedCreateInput!): Nested!
 }

--- a/tests/schema/computedInputs.test.ts
+++ b/tests/schema/computedInputs.test.ts
@@ -61,6 +61,7 @@ const globalTestData = {
   }),
   mutation: Nexus.mutationType({
     definition(t: any) {
+      t.crud.deleteOneUser()
       t.crud.createOneUser()
       t.crud.createOneNested()
     },
@@ -191,6 +192,36 @@ it('handles arrays when recursing for computedInputs', async () => {
           { createdWithBrowser: 'firefox', name: 'Nested Name' },
         ],
       },
+    },
+  })
+})
+
+it('handles undefined data when recursing for computedInputs', async () => {
+  const { datamodel } = globalTestData
+  const dmmf = await getDmmf(datamodel, {
+    globallyComputedInputs: { createdWithBrowser: ({ ctx }) => ctx.browser },
+  })
+
+  expect(
+    await addComputedInputs({
+      params: {
+        info: {} as any,
+        args: {
+          data: undefined,
+          where: {
+            id: 'an id',
+          },
+        },
+        ctx: { browser: 'firefox' },
+      },
+      inputType: dmmf.getInputType('UserWhereUniqueInput'),
+      dmmf,
+      locallyComputedInputs: {},
+    })
+  ).toStrictEqual({
+    data: undefined,
+    where: {
+      id: 'an id',
     },
   })
 })


### PR DESCRIPTION
Fix issue where computed inputs throw an exception for mutations which don't pass data. (i.e. delete mutations)

fixes #678 
fixes #988